### PR TITLE
refactor(hermes): 补齐管理 API、统一 DomainIDPConfig、清理 WithKey 聚合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,13 @@ helios/
 ├── hermes/                          # 数据模块（身份与访问管理数据层）
 │   ├── config/                      # Hermes 配置 + DB 初始化
 │   ├── models/                      # 数据模型（公开，aegis/iris 依赖）
-│   ├── upload/                      # 文件上传 Handler
-│   ├── handler.go                   # HTTP Handler
+│   ├── handler.go                   # HTTP Handler（管理端 CRUD）
 │   ├── service.go                   # 核心服务（Domain/Application/Service/Relationship/Group）
 │   ├── user.go                      # 用户数据服务
-│   ├── credential.go                # 凭证数据服务
-│   └── types.go                     # 请求/响应类型
+│   ├── key.go                       # 密钥管理服务
+│   ├── provision.go                 # 域/应用/服务配置管理
+│   ├── resource.go                  # 关系（ReBAC）管理
+│   └── dto/                         # 请求/响应类型
 ├── iris/                            # 用户信息模块（用户 Profile/MFA/Identity 管理）
 │   ├── config/                      # Iris 配置
 │   └── handler.go                   # HTTP Handler

--- a/aegis/adapter/convert.go
+++ b/aegis/adapter/convert.go
@@ -18,8 +18,31 @@ func ConvertDomain(d *hmodels.Domain) *amodels.Domain {
 		DomainID:    d.DomainID,
 		Name:        d.Name,
 		Description: d.Description,
-		AllowedIDPs: d.AllowedIDPs,
 	}
+}
+
+func ConvertDomainIDPConfig(c *hmodels.DomainIDPConfig) *amodels.DomainIDPConfig {
+	if c == nil {
+		return nil
+	}
+	return &amodels.DomainIDPConfig{
+		ID:        c.ID,
+		DomainID:  c.DomainID,
+		IDPType:   c.IDPType,
+		Priority:  c.Priority,
+		Strategy:  c.Strategy,
+		TAppID:    c.TAppID,
+		CreatedAt: c.CreatedAt,
+		UpdatedAt: c.UpdatedAt,
+	}
+}
+
+func ConvertDomainIDPConfigs(cs []*hmodels.DomainIDPConfig) []*amodels.DomainIDPConfig {
+	result := make([]*amodels.DomainIDPConfig, len(cs))
+	for i, c := range cs {
+		result[i] = ConvertDomainIDPConfig(c)
+	}
+	return result
 }
 
 // ==================== Application ====================

--- a/aegis/adapter/credential_store.go
+++ b/aegis/adapter/credential_store.go
@@ -67,3 +67,11 @@ func (a *CredentialStoreAdapter) DisableCredential(ctx context.Context, credenti
 func (a *CredentialStoreAdapter) DeleteCredential(ctx context.Context, openid, credentialID string) error {
 	return a.svc.DeleteCredential(ctx, openid, credentialID)
 }
+
+func (a *CredentialStoreAdapter) UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error {
+	return a.svc.UpdateCredentialByInternalID(ctx, id, updates)
+}
+
+func (a *CredentialStoreAdapter) DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error {
+	return a.svc.DeleteCredentialByOpenIDAndType(ctx, openid, credType)
+}

--- a/aegis/adapter/credential_store.go
+++ b/aegis/adapter/credential_store.go
@@ -36,14 +36,6 @@ func (a *CredentialStoreAdapter) GetUserCredentialsByType(ctx context.Context, o
 	return ConvertCredentials(cs), nil
 }
 
-func (a *CredentialStoreAdapter) GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]amodels.UserCredential, error) {
-	cs, err := a.svc.GetEnabledUserCredentialsByType(ctx, openid, credType)
-	if err != nil {
-		return nil, err
-	}
-	return ConvertCredentials(cs), nil
-}
-
 func (a *CredentialStoreAdapter) GetCredentialByID(ctx context.Context, credentialID string) (*amodels.UserCredential, error) {
 	c, err := a.svc.GetCredentialByID(ctx, credentialID)
 	if err != nil {
@@ -56,20 +48,12 @@ func (a *CredentialStoreAdapter) UpdateCredential(ctx context.Context, credentia
 	return a.svc.UpdateCredential(ctx, credentialID, updates)
 }
 
-func (a *CredentialStoreAdapter) EnableCredential(ctx context.Context, credentialID string) error {
-	return a.svc.EnableCredential(ctx, credentialID)
-}
-
-func (a *CredentialStoreAdapter) DisableCredential(ctx context.Context, credentialID string) error {
-	return a.svc.DisableCredential(ctx, credentialID)
+func (a *CredentialStoreAdapter) UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error {
+	return a.svc.UpdateCredentialByInternalID(ctx, id, updates)
 }
 
 func (a *CredentialStoreAdapter) DeleteCredential(ctx context.Context, openid, credentialID string) error {
 	return a.svc.DeleteCredential(ctx, openid, credentialID)
-}
-
-func (a *CredentialStoreAdapter) UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error {
-	return a.svc.UpdateCredentialByInternalID(ctx, id, updates)
 }
 
 func (a *CredentialStoreAdapter) DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error {

--- a/aegis/adapter/hermes.go
+++ b/aegis/adapter/hermes.go
@@ -24,6 +24,14 @@ func (a *HermesAdapter) GetDomain(ctx context.Context, domainID string) (*amodel
 	return ConvertDomain(d), nil
 }
 
+func (a *HermesAdapter) GetDomainIDPConfigs(ctx context.Context, domainID string) ([]*amodels.DomainIDPConfig, error) {
+	cs, err := a.svc.GetDomainIDPConfigs(ctx, domainID)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertDomainIDPConfigs(cs), nil
+}
+
 func (a *HermesAdapter) GetApplication(ctx context.Context, appID string) (*amodels.Application, error) {
 	app, err := a.svc.GetApplication(ctx, appID)
 	if err != nil {

--- a/aegis/adapter/user.go
+++ b/aegis/adapter/user.go
@@ -104,8 +104,8 @@ func (a *UserAdapter) GetOpenIDByCredentialID(ctx context.Context, credentialID 
 	return a.svc.GetOpenIDByCredentialID(ctx, credentialID)
 }
 
-func (a *UserAdapter) GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]amodels.UserCredential, error) {
-	cs, err := a.svc.GetEnabledUserCredentialsByType(ctx, openid, credType)
+func (a *UserAdapter) GetUserCredentialsByType(ctx context.Context, openid, credType string) ([]amodels.UserCredential, error) {
+	cs, err := a.svc.GetUserCredentialsByType(ctx, openid, credType)
 	if err != nil {
 		return nil, err
 	}

--- a/aegis/contract/contract.go
+++ b/aegis/contract/contract.go
@@ -35,7 +35,7 @@ type UserProvider interface {
 	UpdateCredentialSignCount(ctx context.Context, credentialID string, signCount uint32) error
 	DeleteCredential(ctx context.Context, openid, credentialID string) error
 	GetOpenIDByCredentialID(ctx context.Context, credentialID string) (string, error)
-	GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error)
+	GetUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error)
 	UpdateUser(ctx context.Context, openid string, updates map[string]any) error
 	UpdatePassword(ctx context.Context, openid, oldPassword, newPassword string) error
 }

--- a/aegis/contract/contract.go
+++ b/aegis/contract/contract.go
@@ -8,6 +8,7 @@ import (
 
 type HermesProvider interface {
 	GetDomain(ctx context.Context, domainID string) (*models.Domain, error)
+	GetDomainIDPConfigs(ctx context.Context, domainID string) ([]*models.DomainIDPConfig, error)
 	GetApplication(ctx context.Context, appID string) (*models.Application, error)
 	GetService(ctx context.Context, serviceID string) (*models.Service, error)
 	GetDomainKeys(ctx context.Context, domainID string) ([][]byte, error)

--- a/aegis/handler.go
+++ b/aegis/handler.go
@@ -988,12 +988,14 @@ func (h *Handler) resolveUser(ctx context.Context, flow *types.AuthFlow) error {
 			return errIdentifiedUser
 		}
 
-		// 未找到已有用户，检查该 IDP 是否在应用所属域的允许列表中（来自 DB）
-		domainWithKey, err := h.cache.GetDomain(ctx, domain)
+		// 未找到已有用户，检查该 IDP 是否在域的 IDP 配置中（有配置即允许）
+		domainIDPConfigs, err := h.cache.GetDomainIDPConfigs(ctx, domain)
 		if err != nil {
-			return fmt.Errorf("get domain: %w", err)
+			return fmt.Errorf("get domain idp configs: %w", err)
 		}
-		if !slices.Contains(domainWithKey.AllowedIDPs, connection) {
+		if !slices.ContainsFunc(domainIDPConfigs, func(cfg *models.DomainIDPConfig) bool {
+			return cfg.IDPType == connection
+		}) {
 			return autherrors.NewAccessDenied("registration not allowed for this IDP")
 		}
 

--- a/aegis/internal/authenticator/webauthn/service.go
+++ b/aegis/internal/authenticator/webauthn/service.go
@@ -394,13 +394,16 @@ func (s *Service) GetOpenIDByCredentialID(ctx context.Context, credentialID stri
 
 // getUserWebAuthnCredentials 获取用户的 WebAuthn 凭证列表
 func (s *Service) getUserWebAuthnCredentials(ctx context.Context, openid string) ([]*StoredWebAuthnCredential, error) {
-	credentials, err := s.userSvc.GetEnabledUserCredentialsByType(ctx, openid, string(models.CredentialTypeWebAuthn))
+	credentials, err := s.userSvc.GetUserCredentialsByType(ctx, openid, string(models.CredentialTypeWebAuthn))
 	if err != nil {
 		return nil, err
 	}
 
 	result := make([]*StoredWebAuthnCredential, 0, len(credentials))
 	for _, cred := range credentials {
+		if !cred.Enabled {
+			continue
+		}
 		stored, err := ParseStoredWebAuthnCredential(&cred)
 		if err != nil {
 			continue

--- a/aegis/internal/cache/hermes.go
+++ b/aegis/internal/cache/hermes.go
@@ -146,6 +146,29 @@ func (cm *Manager) GetAppServiceRelations(ctx context.Context, appID string) ([]
 	return relations, nil
 }
 
+// GetDomainIDPConfigs 获取域 IDP 配置（带缓存）
+func (cm *Manager) GetDomainIDPConfigs(ctx context.Context, domainID string) ([]*models.DomainIDPConfig, error) {
+	cacheKey := config.GetCacheKeyPrefix("domain-idp-config") + domainID
+
+	if cm.domainIDPConfigCache != nil {
+		if cached, ok := cm.domainIDPConfigCache.Get(cacheKey); ok {
+			return cached, nil
+		}
+	}
+
+	configs, err := cm.hermesSvc.GetDomainIDPConfigs(ctx, domainID)
+	if err != nil {
+		return nil, err
+	}
+
+	if cm.domainIDPConfigCache != nil {
+		ttl := config.GetCacheTTL("domain-idp-config")
+		cm.domainIDPConfigCache.SetWithTTL(cacheKey, configs, 1, ttl)
+	}
+
+	return configs, nil
+}
+
 // GetApplicationIDPConfigs 获取应用 IDP 配置（带缓存）
 func (cm *Manager) GetApplicationIDPConfigs(ctx context.Context, appID string) ([]*models.ApplicationIDPConfig, error) {
 	cacheKey := config.GetCacheKeyPrefix("app-idp-config") + appID

--- a/aegis/internal/cache/manager.go
+++ b/aegis/internal/cache/manager.go
@@ -38,6 +38,9 @@ type Manager struct {
 	relationCache    *ristretto.Cache[string, []models.ApplicationServiceRelation]
 	userCache        *ristretto.Cache[string, *models.UserWithDecrypted]
 
+	// 域 IDP 配置缓存：domain_id -> []*DomainIDPConfig
+	domainIDPConfigCache *ristretto.Cache[string, []*models.DomainIDPConfig]
+
 	// 应用 IDP 配置缓存：app_id -> []*ApplicationIDPConfig
 	appIDPConfigCache *ristretto.Cache[string, []*models.ApplicationIDPConfig]
 
@@ -77,6 +80,7 @@ func NewManager(hermesSvc contract.HermesProvider, userSvc contract.UserProvider
 		serviceCache:         newConfiguredCache[*ServiceWithKey]("service"),
 		relationCache:        newConfiguredCache[[]models.ApplicationServiceRelation]("application-service-relation"),
 		userCache:            newConfiguredCache[*models.UserWithDecrypted]("user"),
+		domainIDPConfigCache: newConfiguredCache[[]*models.DomainIDPConfig]("domain-idp-config"),
 		appIDPConfigCache:    newConfiguredCache[[]*models.ApplicationIDPConfig]("app-idp-config"),
 		challengeConfigCache: newConfiguredCache[*models.ServiceChallengeSetting]("challenge-config"),
 		ssoKeyCache:          newCache[*Keys]("sso", 10, 1, 64),
@@ -89,6 +93,7 @@ func (cm *Manager) Close() {
 	cm.serviceCache.Close()
 	cm.relationCache.Close()
 	cm.userCache.Close()
+	cm.domainIDPConfigCache.Close()
 	cm.appIDPConfigCache.Close()
 	cm.challengeConfigCache.Close()
 	cm.ssoKeyCache.Close()

--- a/aegis/models/domain.go
+++ b/aegis/models/domain.go
@@ -1,11 +1,12 @@
 package models
 
+import "time"
+
 // Domain 域（从 proto 转换，不含 GORM 标签）
 type Domain struct {
-	DomainID    string   `json:"domain_id"`
-	Name        string   `json:"name"`
-	Description *string  `json:"description"`
-	AllowedIDPs []string `json:"allowed_idps"`
+	DomainID    string  `json:"domain_id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
 }
 
 // DomainWithKey 带签名密钥的 Domain（Main/Keys 不序列化到 API）
@@ -13,4 +14,16 @@ type DomainWithKey struct {
 	Domain
 	Main []byte   `json:"-"` // 当前主密钥（48 字节 seed）
 	Keys [][]byte `json:"-"` // 所有有效密钥
+}
+
+// DomainIDPConfig 域 IDP 配置（有配置即表示该 IDP 在此域下可用）
+type DomainIDPConfig struct {
+	ID        uint      `json:"id"`
+	DomainID  string    `json:"domain_id"`
+	IDPType   string    `json:"idp_type"`
+	Priority  int       `json:"priority"`
+	Strategy  *string   `json:"strategy,omitempty"`
+	TAppID    string    `json:"t_app_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/aegis/rpc/hermes/convert.go
+++ b/aegis/rpc/hermes/convert.go
@@ -18,6 +18,26 @@ func domainFromProto(pb *hermesv1.Domain) *models.Domain {
 	}
 }
 
+func domainIDPConfigFromProto(pb *hermesv1.DomainIDPConfig) *models.DomainIDPConfig {
+	if pb == nil {
+		return nil
+	}
+	cfg := &models.DomainIDPConfig{
+		ID:       uint(pb.Id),
+		DomainID: pb.DomainId,
+		IDPType:  pb.Type,
+		Priority: int(pb.Priority),
+		Strategy: pb.Strategy,
+	}
+	if pb.CreatedAt != nil {
+		cfg.CreatedAt = pb.CreatedAt.AsTime()
+	}
+	if pb.UpdatedAt != nil {
+		cfg.UpdatedAt = pb.UpdatedAt.AsTime()
+	}
+	return cfg
+}
+
 func applicationFromProto(pb *hermesv1.Application) *models.Application {
 	if pb == nil {
 		return nil

--- a/aegis/rpc/hermes/provision.go
+++ b/aegis/rpc/hermes/provision.go
@@ -18,6 +18,18 @@ func (c *Client) GetDomain(ctx context.Context, domainID string) (*models.Domain
 	return domainFromProto(resp), nil
 }
 
+func (c *Client) GetDomainIDPConfigs(ctx context.Context, domainID string) ([]*models.DomainIDPConfig, error) {
+	resp, err := c.provision.GetDomainIDPConfigs(ctx, &hermesv1.GetDomainRequest{DomainId: domainID})
+	if err != nil {
+		return nil, fmt.Errorf("获取域 IDP 配置失败: %w", err)
+	}
+	configs := make([]*models.DomainIDPConfig, 0, len(resp.GetConfigs()))
+	for _, cfg := range resp.GetConfigs() {
+		configs = append(configs, domainIDPConfigFromProto(cfg))
+	}
+	return configs, nil
+}
+
 // ==================== Application ====================
 
 func (c *Client) GetApplication(ctx context.Context, appID string) (*models.Application, error) {

--- a/aegis/rpc/hermes/user.go
+++ b/aegis/rpc/hermes/user.go
@@ -3,6 +3,9 @@ package hermes
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/heliannuuthus/helios/aegis/models"
 	hermesv1 "github.com/heliannuuthus/helios/gen/proto/hermes/v1"
@@ -291,5 +294,34 @@ func (c *Client) EnableCredential(ctx context.Context, credentialID string) erro
 
 func (c *Client) DisableCredential(ctx context.Context, credentialID string) error {
 	_, err := c.user.DisableCredential(ctx, &hermesv1.CredentialIDRequest{CredentialId: credentialID})
+	return err
+}
+
+func (c *Client) UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error {
+	pbReq := &hermesv1.UpdateCredentialByInternalIDRequest{Id: uint32(id)}
+	if v, ok := updates["enabled"]; ok {
+		if b, ok := v.(bool); ok {
+			pbReq.Enabled = &b
+		}
+	}
+	if v, ok := updates["secret"]; ok {
+		if s, ok := v.(string); ok {
+			pbReq.Secret = &s
+		}
+	}
+	if v, ok := updates["last_used_at"]; ok {
+		if t, ok := v.(time.Time); ok {
+			pbReq.LastUsedAt = timestamppb.New(t)
+		}
+	}
+	_, err := c.user.UpdateCredentialByInternalID(ctx, pbReq)
+	return err
+}
+
+func (c *Client) DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error {
+	_, err := c.user.DeleteCredentialByOpenIDAndType(ctx, &hermesv1.DeleteCredentialByTypeRequest{
+		Openid: openid,
+		Type:   credType,
+	})
 	return err
 }

--- a/aegis/rpc/hermes/user.go
+++ b/aegis/rpc/hermes/user.go
@@ -185,31 +185,15 @@ func (c *Client) GetStaffByIdentifier(ctx context.Context, identifier string) (*
 
 func (c *Client) CreateCredential(ctx context.Context, cred *models.UserCredential) error {
 	pbReq := &hermesv1.CreateCredentialRequest{
-		Openid:  cred.OpenID,
-		Type:    cred.Type,
-		Enabled: cred.Enabled,
-		Secret:  cred.Secret,
+		Openid: cred.OpenID,
+		Type:   cred.Type,
+		Secret: cred.Secret,
 	}
 	if cred.CredentialID != nil {
 		pbReq.CredentialId = cred.CredentialID
 	}
 	_, err := c.user.CreateCredential(ctx, pbReq)
 	return err
-}
-
-func (c *Client) GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
-	resp, err := c.user.GetEnabledUserCredentialsByType(ctx, &hermesv1.GetCredentialsByTypeRequest{
-		Openid: openid,
-		Type:   credType,
-	})
-	if err != nil {
-		return nil, err
-	}
-	creds := make([]models.UserCredential, 0, len(resp.Credentials))
-	for _, cr := range resp.Credentials {
-		creds = append(creds, *credentialFromProto(cr))
-	}
-	return creds, nil
 }
 
 func (c *Client) UpdateCredentialSignCount(ctx context.Context, credentialID string, signCount uint32) error {
@@ -224,6 +208,14 @@ func (c *Client) DeleteCredential(ctx context.Context, openid, credentialID stri
 	_, err := c.user.DeleteCredential(ctx, &hermesv1.DeleteCredentialRequest{
 		Openid:       openid,
 		CredentialId: credentialID,
+	})
+	return err
+}
+
+func (c *Client) DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error {
+	_, err := c.user.DeleteCredentialByOpenIDAndType(ctx, &hermesv1.DeleteCredentialByTypeRequest{
+		Openid: openid,
+		Type:   credType,
 	})
 	return err
 }
@@ -273,27 +265,17 @@ func (c *Client) GetCredentialByID(ctx context.Context, credentialID string) (*m
 
 func (c *Client) UpdateCredential(ctx context.Context, credentialID string, updates map[string]any) error {
 	pbReq := &hermesv1.UpdateCredentialRequest{CredentialId: credentialID}
-	if v, ok := updates["enabled"]; ok {
-		if b, ok := v.(bool); ok {
-			pbReq.Enabled = &b
-		}
-	}
 	if v, ok := updates["secret"]; ok {
 		if s, ok := v.(string); ok {
 			pbReq.Secret = &s
 		}
 	}
+	if v, ok := updates["last_used_at"]; ok {
+		if t, ok := v.(time.Time); ok {
+			pbReq.LastUsedAt = timestamppb.New(t)
+		}
+	}
 	_, err := c.user.UpdateCredential(ctx, pbReq)
-	return err
-}
-
-func (c *Client) EnableCredential(ctx context.Context, credentialID string) error {
-	_, err := c.user.EnableCredential(ctx, &hermesv1.CredentialIDRequest{CredentialId: credentialID})
-	return err
-}
-
-func (c *Client) DisableCredential(ctx context.Context, credentialID string) error {
-	_, err := c.user.DisableCredential(ctx, &hermesv1.CredentialIDRequest{CredentialId: credentialID})
 	return err
 }
 
@@ -315,13 +297,5 @@ func (c *Client) UpdateCredentialByInternalID(ctx context.Context, id uint, upda
 		}
 	}
 	_, err := c.user.UpdateCredentialByInternalID(ctx, pbReq)
-	return err
-}
-
-func (c *Client) DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error {
-	_, err := c.user.DeleteCredentialByOpenIDAndType(ctx, &hermesv1.DeleteCredentialByTypeRequest{
-		Openid: openid,
-		Type:   credType,
-	})
 	return err
 }

--- a/cmd/hermes/main.go
+++ b/cmd/hermes/main.go
@@ -81,7 +81,16 @@ func startHTTP(svc *hermes.Service) {
 			domains.GET("", handler.ListDomains)
 			domains.GET("/:domain_id", handler.GetDomain)
 			domains.PATCH("/:domain_id", adminRelation, handler.UpdateDomain)
-			domains.GET("/:domain_id/idps", handler.GetDomainAllowedIDPs)
+			domains.DELETE("/:domain_id", adminRelation, handler.DeleteDomain)
+
+			domainIDPConfigs := domains.Group("/:domain_id/idp-configs")
+			{
+				domainIDPConfigs.GET("", handler.ListDomainIDPConfigs)
+				domainIDPConfigs.GET("/:idp_type", handler.GetDomainIDPConfig)
+				domainIDPConfigs.POST("", adminRelation, handler.CreateDomainIDPConfig)
+				domainIDPConfigs.PATCH("/:idp_type", adminRelation, handler.UpdateDomainIDPConfig)
+				domainIDPConfigs.DELETE("/:idp_type", adminRelation, handler.DeleteDomainIDPConfig)
+			}
 
 			domainServices := domains.Group("/:domain_id/services")
 			{
@@ -93,6 +102,14 @@ func startHTTP(svc *hermes.Service) {
 				domainServices.POST("", adminRelation, handler.CreateService)
 				domainServices.PATCH("/:service_id", adminRelation, handler.UpdateService)
 				domainServices.DELETE("/:service_id", adminRelation, handler.DeleteService)
+
+				challengeSettings := domainServices.Group("/:service_id/challenge-settings")
+				{
+					challengeSettings.GET("", handler.ListServiceChallengeSettings)
+					challengeSettings.POST("", adminRelation, handler.CreateServiceChallengeSetting)
+					challengeSettings.PATCH("/:type", adminRelation, handler.UpdateServiceChallengeSetting)
+					challengeSettings.DELETE("/:type", adminRelation, handler.DeleteServiceChallengeSetting)
+				}
 			}
 
 			domainApps := domains.Group("/:domain_id/applications")
@@ -103,6 +120,7 @@ func startHTTP(svc *hermes.Service) {
 				domainApps.GET("/:app_id/idp-configs", handler.ListApplicationIDPConfigs)
 				domainApps.POST("", adminRelation, handler.CreateApplication)
 				domainApps.PATCH("/:app_id", adminRelation, handler.UpdateApplication)
+				domainApps.DELETE("/:app_id", adminRelation, handler.DeleteApplication)
 				domainApps.POST("/:app_id/idp-configs", adminRelation, handler.CreateApplicationIDPConfig)
 				domainApps.PATCH("/:app_id/idp-configs/:idp_type", adminRelation, handler.UpdateApplicationIDPConfig)
 				domainApps.DELETE("/:app_id/idp-configs/:idp_type", adminRelation, handler.DeleteApplicationIDPConfig)
@@ -132,7 +150,17 @@ func startHTTP(svc *hermes.Service) {
 			groups.GET("/:group_id/members", handler.GetGroupMembers)
 			groups.POST("", adminRelation, handler.CreateGroup)
 			groups.PATCH("/:group_id", adminRelation, handler.UpdateGroup)
+			groups.DELETE("/:group_id", adminRelation, handler.DeleteGroup)
 			groups.POST("/:group_id/members", adminRelation, handler.SetGroupMembers)
+		}
+
+		idpKeys := api.Group("/idp-keys")
+		{
+			idpKeys.GET("", handler.ListIDPKeys)
+			idpKeys.GET("/:idp_type/:t_app_id", handler.GetIDPKey)
+			idpKeys.POST("", adminRelation, handler.CreateIDPKey)
+			idpKeys.PATCH("/:idp_type/:t_app_id", adminRelation, handler.UpdateIDPKey)
+			idpKeys.DELETE("/:idp_type/:t_app_id", adminRelation, handler.DeleteIDPKey)
 		}
 	}
 

--- a/gen/proto/hermes/v1/user.pb.go
+++ b/gen/proto/hermes/v1/user.pb.go
@@ -1221,8 +1221,7 @@ type CreateCredentialRequest struct {
 	Openid        string                 `protobuf:"bytes,1,opt,name=openid,proto3" json:"openid,omitempty"`
 	CredentialId  *string                `protobuf:"bytes,2,opt,name=credential_id,json=credentialId,proto3,oneof" json:"credential_id,omitempty"`
 	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
-	Enabled       bool                   `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	Secret        string                 `protobuf:"bytes,5,opt,name=secret,proto3" json:"secret,omitempty"`
+	Secret        string                 `protobuf:"bytes,4,opt,name=secret,proto3" json:"secret,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1276,13 +1275,6 @@ func (x *CreateCredentialRequest) GetType() string {
 		return x.Type
 	}
 	return ""
-}
-
-func (x *CreateCredentialRequest) GetEnabled() bool {
-	if x != nil {
-		return x.Enabled
-	}
-	return false
 }
 
 func (x *CreateCredentialRequest) GetSecret() string {
@@ -1347,9 +1339,8 @@ func (x *GetCredentialsByTypeRequest) GetType() string {
 type UpdateCredentialRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CredentialId  string                 `protobuf:"bytes,1,opt,name=credential_id,json=credentialId,proto3" json:"credential_id,omitempty"`
-	Enabled       *bool                  `protobuf:"varint,2,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
-	Secret        *string                `protobuf:"bytes,3,opt,name=secret,proto3,oneof" json:"secret,omitempty"`
-	LastUsedAt    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_used_at,json=lastUsedAt,proto3,oneof" json:"last_used_at,omitempty"`
+	Secret        *string                `protobuf:"bytes,2,opt,name=secret,proto3,oneof" json:"secret,omitempty"`
+	LastUsedAt    *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=last_used_at,json=lastUsedAt,proto3,oneof" json:"last_used_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1389,13 +1380,6 @@ func (x *UpdateCredentialRequest) GetCredentialId() string {
 		return x.CredentialId
 	}
 	return ""
-}
-
-func (x *UpdateCredentialRequest) GetEnabled() bool {
-	if x != nil && x.Enabled != nil {
-		return *x.Enabled
-	}
-	return false
 }
 
 func (x *UpdateCredentialRequest) GetSecret() string {
@@ -2228,25 +2212,21 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"\x0e_credential_idB\x0f\n" +
 	"\r_last_used_at\"Q\n" +
 	"\x12UserCredentialList\x12;\n" +
-	"\vcredentials\x18\x01 \x03(\v2\x19.hermes.v1.UserCredentialR\vcredentials\"\xb3\x01\n" +
+	"\vcredentials\x18\x01 \x03(\v2\x19.hermes.v1.UserCredentialR\vcredentials\"\x99\x01\n" +
 	"\x17CreateCredentialRequest\x12\x16\n" +
 	"\x06openid\x18\x01 \x01(\tR\x06openid\x12(\n" +
 	"\rcredential_id\x18\x02 \x01(\tH\x00R\fcredentialId\x88\x01\x01\x12\x12\n" +
-	"\x04type\x18\x03 \x01(\tR\x04type\x12\x18\n" +
-	"\aenabled\x18\x04 \x01(\bR\aenabled\x12\x16\n" +
-	"\x06secret\x18\x05 \x01(\tR\x06secretB\x10\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12\x16\n" +
+	"\x06secret\x18\x04 \x01(\tR\x06secretB\x10\n" +
 	"\x0e_credential_id\"I\n" +
 	"\x1bGetCredentialsByTypeRequest\x12\x16\n" +
 	"\x06openid\x18\x01 \x01(\tR\x06openid\x12\x12\n" +
-	"\x04type\x18\x02 \x01(\tR\x04type\"\xe5\x01\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\"\xba\x01\n" +
 	"\x17UpdateCredentialRequest\x12#\n" +
-	"\rcredential_id\x18\x01 \x01(\tR\fcredentialId\x12\x1d\n" +
-	"\aenabled\x18\x02 \x01(\bH\x00R\aenabled\x88\x01\x01\x12\x1b\n" +
-	"\x06secret\x18\x03 \x01(\tH\x01R\x06secret\x88\x01\x01\x12A\n" +
-	"\flast_used_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x02R\n" +
-	"lastUsedAt\x88\x01\x01B\n" +
-	"\n" +
-	"\b_enabledB\t\n" +
+	"\rcredential_id\x18\x01 \x01(\tR\fcredentialId\x12\x1b\n" +
+	"\x06secret\x18\x02 \x01(\tH\x00R\x06secret\x88\x01\x01\x12A\n" +
+	"\flast_used_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\n" +
+	"lastUsedAt\x88\x01\x01B\t\n" +
 	"\a_secretB\x0f\n" +
 	"\r_last_used_at\"f\n" +
 	" UpdateCredentialSignCountRequest\x12#\n" +
@@ -2309,7 +2289,7 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"pagination\"N\n" +
 	"\x16SetGroupMembersRequest\x12\x19\n" +
 	"\bgroup_id\x18\x01 \x01(\tR\agroupId\x12\x19\n" +
-	"\buser_ids\x18\x02 \x03(\tR\auserIds2\x91\x16\n" +
+	"\buser_ids\x18\x02 \x03(\tR\auserIds2\x8e\x14\n" +
 	"\vUserService\x128\n" +
 	"\vGetByOpenID\x12\x18.hermes.v1.OpenIDRequest\x1a\x0f.hermes.v1.User\x12A\n" +
 	"\rGetByIdentity\x12\x1f.hermes.v1.GetByIdentityRequest\x1a\x0f.hermes.v1.User\x12D\n" +
@@ -2333,12 +2313,9 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"\x10CreateCredential\x12\".hermes.v1.CreateCredentialRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
 	"\x11GetCredentialByID\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x19.hermes.v1.UserCredential\x12M\n" +
 	"\x12GetUserCredentials\x12\x18.hermes.v1.OpenIDRequest\x1a\x1d.hermes.v1.UserCredentialList\x12a\n" +
-	"\x18GetUserCredentialsByType\x12&.hermes.v1.GetCredentialsByTypeRequest\x1a\x1d.hermes.v1.UserCredentialList\x12h\n" +
-	"\x1fGetEnabledUserCredentialsByType\x12&.hermes.v1.GetCredentialsByTypeRequest\x1a\x1d.hermes.v1.UserCredentialList\x12N\n" +
+	"\x18GetUserCredentialsByType\x12&.hermes.v1.GetCredentialsByTypeRequest\x1a\x1d.hermes.v1.UserCredentialList\x12N\n" +
 	"\x10UpdateCredential\x12\".hermes.v1.UpdateCredentialRequest\x1a\x16.google.protobuf.Empty\x12`\n" +
-	"\x19UpdateCredentialSignCount\x12+.hermes.v1.UpdateCredentialSignCountRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
-	"\x10EnableCredential\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x16.google.protobuf.Empty\x12K\n" +
-	"\x11DisableCredential\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
+	"\x19UpdateCredentialSignCount\x12+.hermes.v1.UpdateCredentialSignCountRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
 	"\x10DeleteCredential\x12\".hermes.v1.DeleteCredentialRequest\x1a\x16.google.protobuf.Empty\x12c\n" +
 	"\x1fDeleteCredentialByOpenIDAndType\x12(.hermes.v1.DeleteCredentialByTypeRequest\x1a\x16.google.protobuf.Empty\x12f\n" +
 	"\x1cUpdateCredentialByInternalID\x12..hermes.v1.UpdateCredentialByInternalIDRequest\x1a\x16.google.protobuf.Empty\x12T\n" +
@@ -2447,60 +2424,54 @@ var file_hermes_v1_user_proto_depIdxs = []int32{
 	15, // 36: hermes.v1.UserService.GetCredentialByID:input_type -> hermes.v1.CredentialIDRequest
 	35, // 37: hermes.v1.UserService.GetUserCredentials:input_type -> hermes.v1.OpenIDRequest
 	19, // 38: hermes.v1.UserService.GetUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
-	19, // 39: hermes.v1.UserService.GetEnabledUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
-	20, // 40: hermes.v1.UserService.UpdateCredential:input_type -> hermes.v1.UpdateCredentialRequest
-	21, // 41: hermes.v1.UserService.UpdateCredentialSignCount:input_type -> hermes.v1.UpdateCredentialSignCountRequest
-	15, // 42: hermes.v1.UserService.EnableCredential:input_type -> hermes.v1.CredentialIDRequest
-	15, // 43: hermes.v1.UserService.DisableCredential:input_type -> hermes.v1.CredentialIDRequest
-	22, // 44: hermes.v1.UserService.DeleteCredential:input_type -> hermes.v1.DeleteCredentialRequest
-	23, // 45: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:input_type -> hermes.v1.DeleteCredentialByTypeRequest
-	24, // 46: hermes.v1.UserService.UpdateCredentialByInternalID:input_type -> hermes.v1.UpdateCredentialByInternalIDRequest
-	15, // 47: hermes.v1.UserService.GetOpenIDByCredentialID:input_type -> hermes.v1.CredentialIDRequest
-	29, // 48: hermes.v1.UserService.CreateGroup:input_type -> hermes.v1.CreateGroupRequest
-	28, // 49: hermes.v1.UserService.GetGroup:input_type -> hermes.v1.GetGroupRequest
-	31, // 50: hermes.v1.UserService.ListGroups:input_type -> hermes.v1.ListGroupsRequest
-	30, // 51: hermes.v1.UserService.UpdateGroup:input_type -> hermes.v1.UpdateGroupRequest
-	28, // 52: hermes.v1.UserService.DeleteGroup:input_type -> hermes.v1.GetGroupRequest
-	32, // 53: hermes.v1.UserService.SetGroupMembers:input_type -> hermes.v1.SetGroupMembersRequest
-	28, // 54: hermes.v1.UserService.GetGroupMembers:input_type -> hermes.v1.GetGroupRequest
-	0,  // 55: hermes.v1.UserService.GetByOpenID:output_type -> hermes.v1.User
-	0,  // 56: hermes.v1.UserService.GetByIdentity:output_type -> hermes.v1.User
-	1,  // 57: hermes.v1.UserService.GetByEmail:output_type -> hermes.v1.DecryptedUser
-	1,  // 58: hermes.v1.UserService.GetByPhonePlain:output_type -> hermes.v1.DecryptedUser
-	1,  // 59: hermes.v1.UserService.GetDecryptedUser:output_type -> hermes.v1.DecryptedUser
-	1,  // 60: hermes.v1.UserService.GetDecryptedUserByIdentity:output_type -> hermes.v1.DecryptedUser
-	1,  // 61: hermes.v1.UserService.CreateUser:output_type -> hermes.v1.DecryptedUser
-	0,  // 62: hermes.v1.UserService.UpdateUser:output_type -> hermes.v1.User
-	36, // 63: hermes.v1.UserService.UpdateLastLogin:output_type -> google.protobuf.Empty
-	36, // 64: hermes.v1.UserService.UpdatePassword:output_type -> google.protobuf.Empty
-	10, // 65: hermes.v1.UserService.GetIdentities:output_type -> hermes.v1.IdentityList
-	10, // 66: hermes.v1.UserService.GetIdentitiesByIdentity:output_type -> hermes.v1.IdentityList
-	9,  // 67: hermes.v1.UserService.GetIdentityByType:output_type -> hermes.v1.UserIdentity
-	36, // 68: hermes.v1.UserService.AddIdentity:output_type -> google.protobuf.Empty
-	14, // 69: hermes.v1.UserService.GetUserByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
-	14, // 70: hermes.v1.UserService.GetStaffByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
-	36, // 71: hermes.v1.UserService.CreateCredential:output_type -> google.protobuf.Empty
-	16, // 72: hermes.v1.UserService.GetCredentialByID:output_type -> hermes.v1.UserCredential
-	17, // 73: hermes.v1.UserService.GetUserCredentials:output_type -> hermes.v1.UserCredentialList
-	17, // 74: hermes.v1.UserService.GetUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
-	17, // 75: hermes.v1.UserService.GetEnabledUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
-	36, // 76: hermes.v1.UserService.UpdateCredential:output_type -> google.protobuf.Empty
-	36, // 77: hermes.v1.UserService.UpdateCredentialSignCount:output_type -> google.protobuf.Empty
-	36, // 78: hermes.v1.UserService.EnableCredential:output_type -> google.protobuf.Empty
-	36, // 79: hermes.v1.UserService.DisableCredential:output_type -> google.protobuf.Empty
-	36, // 80: hermes.v1.UserService.DeleteCredential:output_type -> google.protobuf.Empty
-	36, // 81: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:output_type -> google.protobuf.Empty
-	36, // 82: hermes.v1.UserService.UpdateCredentialByInternalID:output_type -> google.protobuf.Empty
-	25, // 83: hermes.v1.UserService.GetOpenIDByCredentialID:output_type -> hermes.v1.OpenIDResponse
-	26, // 84: hermes.v1.UserService.CreateGroup:output_type -> hermes.v1.Group
-	26, // 85: hermes.v1.UserService.GetGroup:output_type -> hermes.v1.Group
-	27, // 86: hermes.v1.UserService.ListGroups:output_type -> hermes.v1.GroupList
-	26, // 87: hermes.v1.UserService.UpdateGroup:output_type -> hermes.v1.Group
-	36, // 88: hermes.v1.UserService.DeleteGroup:output_type -> google.protobuf.Empty
-	36, // 89: hermes.v1.UserService.SetGroupMembers:output_type -> google.protobuf.Empty
-	37, // 90: hermes.v1.UserService.GetGroupMembers:output_type -> hermes.v1.StringList
-	55, // [55:91] is the sub-list for method output_type
-	19, // [19:55] is the sub-list for method input_type
+	20, // 39: hermes.v1.UserService.UpdateCredential:input_type -> hermes.v1.UpdateCredentialRequest
+	21, // 40: hermes.v1.UserService.UpdateCredentialSignCount:input_type -> hermes.v1.UpdateCredentialSignCountRequest
+	22, // 41: hermes.v1.UserService.DeleteCredential:input_type -> hermes.v1.DeleteCredentialRequest
+	23, // 42: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:input_type -> hermes.v1.DeleteCredentialByTypeRequest
+	24, // 43: hermes.v1.UserService.UpdateCredentialByInternalID:input_type -> hermes.v1.UpdateCredentialByInternalIDRequest
+	15, // 44: hermes.v1.UserService.GetOpenIDByCredentialID:input_type -> hermes.v1.CredentialIDRequest
+	29, // 45: hermes.v1.UserService.CreateGroup:input_type -> hermes.v1.CreateGroupRequest
+	28, // 46: hermes.v1.UserService.GetGroup:input_type -> hermes.v1.GetGroupRequest
+	31, // 47: hermes.v1.UserService.ListGroups:input_type -> hermes.v1.ListGroupsRequest
+	30, // 48: hermes.v1.UserService.UpdateGroup:input_type -> hermes.v1.UpdateGroupRequest
+	28, // 49: hermes.v1.UserService.DeleteGroup:input_type -> hermes.v1.GetGroupRequest
+	32, // 50: hermes.v1.UserService.SetGroupMembers:input_type -> hermes.v1.SetGroupMembersRequest
+	28, // 51: hermes.v1.UserService.GetGroupMembers:input_type -> hermes.v1.GetGroupRequest
+	0,  // 52: hermes.v1.UserService.GetByOpenID:output_type -> hermes.v1.User
+	0,  // 53: hermes.v1.UserService.GetByIdentity:output_type -> hermes.v1.User
+	1,  // 54: hermes.v1.UserService.GetByEmail:output_type -> hermes.v1.DecryptedUser
+	1,  // 55: hermes.v1.UserService.GetByPhonePlain:output_type -> hermes.v1.DecryptedUser
+	1,  // 56: hermes.v1.UserService.GetDecryptedUser:output_type -> hermes.v1.DecryptedUser
+	1,  // 57: hermes.v1.UserService.GetDecryptedUserByIdentity:output_type -> hermes.v1.DecryptedUser
+	1,  // 58: hermes.v1.UserService.CreateUser:output_type -> hermes.v1.DecryptedUser
+	0,  // 59: hermes.v1.UserService.UpdateUser:output_type -> hermes.v1.User
+	36, // 60: hermes.v1.UserService.UpdateLastLogin:output_type -> google.protobuf.Empty
+	36, // 61: hermes.v1.UserService.UpdatePassword:output_type -> google.protobuf.Empty
+	10, // 62: hermes.v1.UserService.GetIdentities:output_type -> hermes.v1.IdentityList
+	10, // 63: hermes.v1.UserService.GetIdentitiesByIdentity:output_type -> hermes.v1.IdentityList
+	9,  // 64: hermes.v1.UserService.GetIdentityByType:output_type -> hermes.v1.UserIdentity
+	36, // 65: hermes.v1.UserService.AddIdentity:output_type -> google.protobuf.Empty
+	14, // 66: hermes.v1.UserService.GetUserByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
+	14, // 67: hermes.v1.UserService.GetStaffByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
+	36, // 68: hermes.v1.UserService.CreateCredential:output_type -> google.protobuf.Empty
+	16, // 69: hermes.v1.UserService.GetCredentialByID:output_type -> hermes.v1.UserCredential
+	17, // 70: hermes.v1.UserService.GetUserCredentials:output_type -> hermes.v1.UserCredentialList
+	17, // 71: hermes.v1.UserService.GetUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
+	36, // 72: hermes.v1.UserService.UpdateCredential:output_type -> google.protobuf.Empty
+	36, // 73: hermes.v1.UserService.UpdateCredentialSignCount:output_type -> google.protobuf.Empty
+	36, // 74: hermes.v1.UserService.DeleteCredential:output_type -> google.protobuf.Empty
+	36, // 75: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:output_type -> google.protobuf.Empty
+	36, // 76: hermes.v1.UserService.UpdateCredentialByInternalID:output_type -> google.protobuf.Empty
+	25, // 77: hermes.v1.UserService.GetOpenIDByCredentialID:output_type -> hermes.v1.OpenIDResponse
+	26, // 78: hermes.v1.UserService.CreateGroup:output_type -> hermes.v1.Group
+	26, // 79: hermes.v1.UserService.GetGroup:output_type -> hermes.v1.Group
+	27, // 80: hermes.v1.UserService.ListGroups:output_type -> hermes.v1.GroupList
+	26, // 81: hermes.v1.UserService.UpdateGroup:output_type -> hermes.v1.Group
+	36, // 82: hermes.v1.UserService.DeleteGroup:output_type -> google.protobuf.Empty
+	36, // 83: hermes.v1.UserService.SetGroupMembers:output_type -> google.protobuf.Empty
+	37, // 84: hermes.v1.UserService.GetGroupMembers:output_type -> hermes.v1.StringList
+	52, // [52:85] is the sub-list for method output_type
+	19, // [19:52] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
 	19, // [19:19] is the sub-list for extension extendee
 	0,  // [0:19] is the sub-list for field type_name

--- a/gen/proto/hermes/v1/user.pb.go
+++ b/gen/proto/hermes/v1/user.pb.go
@@ -1516,6 +1516,126 @@ func (x *DeleteCredentialRequest) GetCredentialId() string {
 	return ""
 }
 
+type DeleteCredentialByTypeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Openid        string                 `protobuf:"bytes,1,opt,name=openid,proto3" json:"openid,omitempty"`
+	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteCredentialByTypeRequest) Reset() {
+	*x = DeleteCredentialByTypeRequest{}
+	mi := &file_hermes_v1_user_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteCredentialByTypeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteCredentialByTypeRequest) ProtoMessage() {}
+
+func (x *DeleteCredentialByTypeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hermes_v1_user_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteCredentialByTypeRequest.ProtoReflect.Descriptor instead.
+func (*DeleteCredentialByTypeRequest) Descriptor() ([]byte, []int) {
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *DeleteCredentialByTypeRequest) GetOpenid() string {
+	if x != nil {
+		return x.Openid
+	}
+	return ""
+}
+
+func (x *DeleteCredentialByTypeRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+type UpdateCredentialByInternalIDRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Enabled       *bool                  `protobuf:"varint,2,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	Secret        *string                `protobuf:"bytes,3,opt,name=secret,proto3,oneof" json:"secret,omitempty"`
+	LastUsedAt    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_used_at,json=lastUsedAt,proto3,oneof" json:"last_used_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateCredentialByInternalIDRequest) Reset() {
+	*x = UpdateCredentialByInternalIDRequest{}
+	mi := &file_hermes_v1_user_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateCredentialByInternalIDRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateCredentialByInternalIDRequest) ProtoMessage() {}
+
+func (x *UpdateCredentialByInternalIDRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hermes_v1_user_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateCredentialByInternalIDRequest.ProtoReflect.Descriptor instead.
+func (*UpdateCredentialByInternalIDRequest) Descriptor() ([]byte, []int) {
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *UpdateCredentialByInternalIDRequest) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *UpdateCredentialByInternalIDRequest) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+func (x *UpdateCredentialByInternalIDRequest) GetSecret() string {
+	if x != nil && x.Secret != nil {
+		return *x.Secret
+	}
+	return ""
+}
+
+func (x *UpdateCredentialByInternalIDRequest) GetLastUsedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastUsedAt
+	}
+	return nil
+}
+
 type OpenIDResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Openid        string                 `protobuf:"bytes,1,opt,name=openid,proto3" json:"openid,omitempty"`
@@ -1525,7 +1645,7 @@ type OpenIDResponse struct {
 
 func (x *OpenIDResponse) Reset() {
 	*x = OpenIDResponse{}
-	mi := &file_hermes_v1_user_proto_msgTypes[23]
+	mi := &file_hermes_v1_user_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1537,7 +1657,7 @@ func (x *OpenIDResponse) String() string {
 func (*OpenIDResponse) ProtoMessage() {}
 
 func (x *OpenIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[23]
+	mi := &file_hermes_v1_user_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1550,7 +1670,7 @@ func (x *OpenIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenIDResponse.ProtoReflect.Descriptor instead.
 func (*OpenIDResponse) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{23}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *OpenIDResponse) GetOpenid() string {
@@ -1575,7 +1695,7 @@ type Group struct {
 
 func (x *Group) Reset() {
 	*x = Group{}
-	mi := &file_hermes_v1_user_proto_msgTypes[24]
+	mi := &file_hermes_v1_user_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1707,7 @@ func (x *Group) String() string {
 func (*Group) ProtoMessage() {}
 
 func (x *Group) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[24]
+	mi := &file_hermes_v1_user_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1720,7 @@ func (x *Group) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Group.ProtoReflect.Descriptor instead.
 func (*Group) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{24}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Group) GetId() uint32 {
@@ -1662,7 +1782,7 @@ type GroupList struct {
 
 func (x *GroupList) Reset() {
 	*x = GroupList{}
-	mi := &file_hermes_v1_user_proto_msgTypes[25]
+	mi := &file_hermes_v1_user_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1674,7 +1794,7 @@ func (x *GroupList) String() string {
 func (*GroupList) ProtoMessage() {}
 
 func (x *GroupList) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[25]
+	mi := &file_hermes_v1_user_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1687,7 +1807,7 @@ func (x *GroupList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupList.ProtoReflect.Descriptor instead.
 func (*GroupList) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{25}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GroupList) GetGroups() []*Group {
@@ -1713,7 +1833,7 @@ type GetGroupRequest struct {
 
 func (x *GetGroupRequest) Reset() {
 	*x = GetGroupRequest{}
-	mi := &file_hermes_v1_user_proto_msgTypes[26]
+	mi := &file_hermes_v1_user_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1725,7 +1845,7 @@ func (x *GetGroupRequest) String() string {
 func (*GetGroupRequest) ProtoMessage() {}
 
 func (x *GetGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[26]
+	mi := &file_hermes_v1_user_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1738,7 +1858,7 @@ func (x *GetGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGroupRequest.ProtoReflect.Descriptor instead.
 func (*GetGroupRequest) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{26}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetGroupRequest) GetGroupId() string {
@@ -1760,7 +1880,7 @@ type CreateGroupRequest struct {
 
 func (x *CreateGroupRequest) Reset() {
 	*x = CreateGroupRequest{}
-	mi := &file_hermes_v1_user_proto_msgTypes[27]
+	mi := &file_hermes_v1_user_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1772,7 +1892,7 @@ func (x *CreateGroupRequest) String() string {
 func (*CreateGroupRequest) ProtoMessage() {}
 
 func (x *CreateGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[27]
+	mi := &file_hermes_v1_user_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1785,7 +1905,7 @@ func (x *CreateGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateGroupRequest.ProtoReflect.Descriptor instead.
 func (*CreateGroupRequest) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{27}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *CreateGroupRequest) GetGroupId() string {
@@ -1827,7 +1947,7 @@ type UpdateGroupRequest struct {
 
 func (x *UpdateGroupRequest) Reset() {
 	*x = UpdateGroupRequest{}
-	mi := &file_hermes_v1_user_proto_msgTypes[28]
+	mi := &file_hermes_v1_user_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1839,7 +1959,7 @@ func (x *UpdateGroupRequest) String() string {
 func (*UpdateGroupRequest) ProtoMessage() {}
 
 func (x *UpdateGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[28]
+	mi := &file_hermes_v1_user_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1852,7 +1972,7 @@ func (x *UpdateGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGroupRequest.ProtoReflect.Descriptor instead.
 func (*UpdateGroupRequest) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{28}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UpdateGroupRequest) GetGroupId() string {
@@ -1886,7 +2006,7 @@ type ListGroupsRequest struct {
 
 func (x *ListGroupsRequest) Reset() {
 	*x = ListGroupsRequest{}
-	mi := &file_hermes_v1_user_proto_msgTypes[29]
+	mi := &file_hermes_v1_user_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1898,7 +2018,7 @@ func (x *ListGroupsRequest) String() string {
 func (*ListGroupsRequest) ProtoMessage() {}
 
 func (x *ListGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[29]
+	mi := &file_hermes_v1_user_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1911,7 +2031,7 @@ func (x *ListGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{29}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListGroupsRequest) GetFilter() string {
@@ -1938,7 +2058,7 @@ type SetGroupMembersRequest struct {
 
 func (x *SetGroupMembersRequest) Reset() {
 	*x = SetGroupMembersRequest{}
-	mi := &file_hermes_v1_user_proto_msgTypes[30]
+	mi := &file_hermes_v1_user_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1950,7 +2070,7 @@ func (x *SetGroupMembersRequest) String() string {
 func (*SetGroupMembersRequest) ProtoMessage() {}
 
 func (x *SetGroupMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hermes_v1_user_proto_msgTypes[30]
+	mi := &file_hermes_v1_user_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1963,7 +2083,7 @@ func (x *SetGroupMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetGroupMembersRequest.ProtoReflect.Descriptor instead.
 func (*SetGroupMembersRequest) Descriptor() ([]byte, []int) {
-	return file_hermes_v1_user_proto_rawDescGZIP(), []int{30}
+	return file_hermes_v1_user_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SetGroupMembersRequest) GetGroupId() string {
@@ -2135,7 +2255,20 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"sign_count\x18\x02 \x01(\rR\tsignCount\"V\n" +
 	"\x17DeleteCredentialRequest\x12\x16\n" +
 	"\x06openid\x18\x01 \x01(\tR\x06openid\x12#\n" +
-	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\"(\n" +
+	"\rcredential_id\x18\x02 \x01(\tR\fcredentialId\"K\n" +
+	"\x1dDeleteCredentialByTypeRequest\x12\x16\n" +
+	"\x06openid\x18\x01 \x01(\tR\x06openid\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\"\xdc\x01\n" +
+	"#UpdateCredentialByInternalIDRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\x12\x1d\n" +
+	"\aenabled\x18\x02 \x01(\bH\x00R\aenabled\x88\x01\x01\x12\x1b\n" +
+	"\x06secret\x18\x03 \x01(\tH\x01R\x06secret\x88\x01\x01\x12A\n" +
+	"\flast_used_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x02R\n" +
+	"lastUsedAt\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabledB\t\n" +
+	"\a_secretB\x0f\n" +
+	"\r_last_used_at\"(\n" +
 	"\x0eOpenIDResponse\x12\x16\n" +
 	"\x06openid\x18\x01 \x01(\tR\x06openid\"\x92\x02\n" +
 	"\x05Group\x12\x0e\n" +
@@ -2176,7 +2309,7 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"pagination\"N\n" +
 	"\x16SetGroupMembersRequest\x12\x19\n" +
 	"\bgroup_id\x18\x01 \x01(\tR\agroupId\x12\x19\n" +
-	"\buser_ids\x18\x02 \x03(\tR\auserIds2\xc4\x14\n" +
+	"\buser_ids\x18\x02 \x03(\tR\auserIds2\x91\x16\n" +
 	"\vUserService\x128\n" +
 	"\vGetByOpenID\x12\x18.hermes.v1.OpenIDRequest\x1a\x0f.hermes.v1.User\x12A\n" +
 	"\rGetByIdentity\x12\x1f.hermes.v1.GetByIdentityRequest\x1a\x0f.hermes.v1.User\x12D\n" +
@@ -2206,7 +2339,9 @@ const file_hermes_v1_user_proto_rawDesc = "" +
 	"\x19UpdateCredentialSignCount\x12+.hermes.v1.UpdateCredentialSignCountRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
 	"\x10EnableCredential\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x16.google.protobuf.Empty\x12K\n" +
 	"\x11DisableCredential\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
-	"\x10DeleteCredential\x12\".hermes.v1.DeleteCredentialRequest\x1a\x16.google.protobuf.Empty\x12T\n" +
+	"\x10DeleteCredential\x12\".hermes.v1.DeleteCredentialRequest\x1a\x16.google.protobuf.Empty\x12c\n" +
+	"\x1fDeleteCredentialByOpenIDAndType\x12(.hermes.v1.DeleteCredentialByTypeRequest\x1a\x16.google.protobuf.Empty\x12f\n" +
+	"\x1cUpdateCredentialByInternalID\x12..hermes.v1.UpdateCredentialByInternalIDRequest\x1a\x16.google.protobuf.Empty\x12T\n" +
 	"\x17GetOpenIDByCredentialID\x12\x1e.hermes.v1.CredentialIDRequest\x1a\x19.hermes.v1.OpenIDResponse\x12>\n" +
 	"\vCreateGroup\x12\x1d.hermes.v1.CreateGroupRequest\x1a\x10.hermes.v1.Group\x128\n" +
 	"\bGetGroup\x12\x1a.hermes.v1.GetGroupRequest\x1a\x10.hermes.v1.Group\x12@\n" +
@@ -2231,137 +2366,144 @@ func file_hermes_v1_user_proto_rawDescGZIP() []byte {
 	return file_hermes_v1_user_proto_rawDescData
 }
 
-var file_hermes_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_hermes_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_hermes_v1_user_proto_goTypes = []any{
-	(*User)(nil),                             // 0: hermes.v1.User
-	(*DecryptedUser)(nil),                    // 1: hermes.v1.DecryptedUser
-	(*GetByIdentityRequest)(nil),             // 2: hermes.v1.GetByIdentityRequest
-	(*GetByEmailRequest)(nil),                // 3: hermes.v1.GetByEmailRequest
-	(*GetByPhonePlainRequest)(nil),           // 4: hermes.v1.GetByPhonePlainRequest
-	(*CreateUserRequest)(nil),                // 5: hermes.v1.CreateUserRequest
-	(*TUserInfo)(nil),                        // 6: hermes.v1.TUserInfo
-	(*UpdateUserRequest)(nil),                // 7: hermes.v1.UpdateUserRequest
-	(*UpdatePasswordRequest)(nil),            // 8: hermes.v1.UpdatePasswordRequest
-	(*UserIdentity)(nil),                     // 9: hermes.v1.UserIdentity
-	(*IdentityList)(nil),                     // 10: hermes.v1.IdentityList
-	(*GetIdentityByTypeRequest)(nil),         // 11: hermes.v1.GetIdentityByTypeRequest
-	(*AddIdentityRequest)(nil),               // 12: hermes.v1.AddIdentityRequest
-	(*GetByIdentifierRequest)(nil),           // 13: hermes.v1.GetByIdentifierRequest
-	(*PasswordStoreCredential)(nil),          // 14: hermes.v1.PasswordStoreCredential
-	(*CredentialIDRequest)(nil),              // 15: hermes.v1.CredentialIDRequest
-	(*UserCredential)(nil),                   // 16: hermes.v1.UserCredential
-	(*UserCredentialList)(nil),               // 17: hermes.v1.UserCredentialList
-	(*CreateCredentialRequest)(nil),          // 18: hermes.v1.CreateCredentialRequest
-	(*GetCredentialsByTypeRequest)(nil),      // 19: hermes.v1.GetCredentialsByTypeRequest
-	(*UpdateCredentialRequest)(nil),          // 20: hermes.v1.UpdateCredentialRequest
-	(*UpdateCredentialSignCountRequest)(nil), // 21: hermes.v1.UpdateCredentialSignCountRequest
-	(*DeleteCredentialRequest)(nil),          // 22: hermes.v1.DeleteCredentialRequest
-	(*OpenIDResponse)(nil),                   // 23: hermes.v1.OpenIDResponse
-	(*Group)(nil),                            // 24: hermes.v1.Group
-	(*GroupList)(nil),                        // 25: hermes.v1.GroupList
-	(*GetGroupRequest)(nil),                  // 26: hermes.v1.GetGroupRequest
-	(*CreateGroupRequest)(nil),               // 27: hermes.v1.CreateGroupRequest
-	(*UpdateGroupRequest)(nil),               // 28: hermes.v1.UpdateGroupRequest
-	(*ListGroupsRequest)(nil),                // 29: hermes.v1.ListGroupsRequest
-	(*SetGroupMembersRequest)(nil),           // 30: hermes.v1.SetGroupMembersRequest
-	(*timestamppb.Timestamp)(nil),            // 31: google.protobuf.Timestamp
-	(*Pagination)(nil),                       // 32: hermes.v1.Pagination
-	(*OpenIDRequest)(nil),                    // 33: hermes.v1.OpenIDRequest
-	(*emptypb.Empty)(nil),                    // 34: google.protobuf.Empty
-	(*StringList)(nil),                       // 35: hermes.v1.StringList
+	(*User)(nil),                                // 0: hermes.v1.User
+	(*DecryptedUser)(nil),                       // 1: hermes.v1.DecryptedUser
+	(*GetByIdentityRequest)(nil),                // 2: hermes.v1.GetByIdentityRequest
+	(*GetByEmailRequest)(nil),                   // 3: hermes.v1.GetByEmailRequest
+	(*GetByPhonePlainRequest)(nil),              // 4: hermes.v1.GetByPhonePlainRequest
+	(*CreateUserRequest)(nil),                   // 5: hermes.v1.CreateUserRequest
+	(*TUserInfo)(nil),                           // 6: hermes.v1.TUserInfo
+	(*UpdateUserRequest)(nil),                   // 7: hermes.v1.UpdateUserRequest
+	(*UpdatePasswordRequest)(nil),               // 8: hermes.v1.UpdatePasswordRequest
+	(*UserIdentity)(nil),                        // 9: hermes.v1.UserIdentity
+	(*IdentityList)(nil),                        // 10: hermes.v1.IdentityList
+	(*GetIdentityByTypeRequest)(nil),            // 11: hermes.v1.GetIdentityByTypeRequest
+	(*AddIdentityRequest)(nil),                  // 12: hermes.v1.AddIdentityRequest
+	(*GetByIdentifierRequest)(nil),              // 13: hermes.v1.GetByIdentifierRequest
+	(*PasswordStoreCredential)(nil),             // 14: hermes.v1.PasswordStoreCredential
+	(*CredentialIDRequest)(nil),                 // 15: hermes.v1.CredentialIDRequest
+	(*UserCredential)(nil),                      // 16: hermes.v1.UserCredential
+	(*UserCredentialList)(nil),                  // 17: hermes.v1.UserCredentialList
+	(*CreateCredentialRequest)(nil),             // 18: hermes.v1.CreateCredentialRequest
+	(*GetCredentialsByTypeRequest)(nil),         // 19: hermes.v1.GetCredentialsByTypeRequest
+	(*UpdateCredentialRequest)(nil),             // 20: hermes.v1.UpdateCredentialRequest
+	(*UpdateCredentialSignCountRequest)(nil),    // 21: hermes.v1.UpdateCredentialSignCountRequest
+	(*DeleteCredentialRequest)(nil),             // 22: hermes.v1.DeleteCredentialRequest
+	(*DeleteCredentialByTypeRequest)(nil),       // 23: hermes.v1.DeleteCredentialByTypeRequest
+	(*UpdateCredentialByInternalIDRequest)(nil), // 24: hermes.v1.UpdateCredentialByInternalIDRequest
+	(*OpenIDResponse)(nil),                      // 25: hermes.v1.OpenIDResponse
+	(*Group)(nil),                               // 26: hermes.v1.Group
+	(*GroupList)(nil),                           // 27: hermes.v1.GroupList
+	(*GetGroupRequest)(nil),                     // 28: hermes.v1.GetGroupRequest
+	(*CreateGroupRequest)(nil),                  // 29: hermes.v1.CreateGroupRequest
+	(*UpdateGroupRequest)(nil),                  // 30: hermes.v1.UpdateGroupRequest
+	(*ListGroupsRequest)(nil),                   // 31: hermes.v1.ListGroupsRequest
+	(*SetGroupMembersRequest)(nil),              // 32: hermes.v1.SetGroupMembersRequest
+	(*timestamppb.Timestamp)(nil),               // 33: google.protobuf.Timestamp
+	(*Pagination)(nil),                          // 34: hermes.v1.Pagination
+	(*OpenIDRequest)(nil),                       // 35: hermes.v1.OpenIDRequest
+	(*emptypb.Empty)(nil),                       // 36: google.protobuf.Empty
+	(*StringList)(nil),                          // 37: hermes.v1.StringList
 }
 var file_hermes_v1_user_proto_depIdxs = []int32{
-	31, // 0: hermes.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
-	31, // 1: hermes.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	31, // 2: hermes.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	33, // 0: hermes.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
+	33, // 1: hermes.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	33, // 2: hermes.v1.User.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 3: hermes.v1.DecryptedUser.user:type_name -> hermes.v1.User
 	9,  // 4: hermes.v1.CreateUserRequest.identity:type_name -> hermes.v1.UserIdentity
 	6,  // 5: hermes.v1.CreateUserRequest.user_info:type_name -> hermes.v1.TUserInfo
-	31, // 6: hermes.v1.UserIdentity.created_at:type_name -> google.protobuf.Timestamp
-	31, // 7: hermes.v1.UserIdentity.updated_at:type_name -> google.protobuf.Timestamp
+	33, // 6: hermes.v1.UserIdentity.created_at:type_name -> google.protobuf.Timestamp
+	33, // 7: hermes.v1.UserIdentity.updated_at:type_name -> google.protobuf.Timestamp
 	9,  // 8: hermes.v1.IdentityList.identities:type_name -> hermes.v1.UserIdentity
-	31, // 9: hermes.v1.UserCredential.last_used_at:type_name -> google.protobuf.Timestamp
-	31, // 10: hermes.v1.UserCredential.created_at:type_name -> google.protobuf.Timestamp
-	31, // 11: hermes.v1.UserCredential.updated_at:type_name -> google.protobuf.Timestamp
+	33, // 9: hermes.v1.UserCredential.last_used_at:type_name -> google.protobuf.Timestamp
+	33, // 10: hermes.v1.UserCredential.created_at:type_name -> google.protobuf.Timestamp
+	33, // 11: hermes.v1.UserCredential.updated_at:type_name -> google.protobuf.Timestamp
 	16, // 12: hermes.v1.UserCredentialList.credentials:type_name -> hermes.v1.UserCredential
-	31, // 13: hermes.v1.UpdateCredentialRequest.last_used_at:type_name -> google.protobuf.Timestamp
-	31, // 14: hermes.v1.Group.created_at:type_name -> google.protobuf.Timestamp
-	31, // 15: hermes.v1.Group.updated_at:type_name -> google.protobuf.Timestamp
-	24, // 16: hermes.v1.GroupList.groups:type_name -> hermes.v1.Group
-	32, // 17: hermes.v1.ListGroupsRequest.pagination:type_name -> hermes.v1.Pagination
-	33, // 18: hermes.v1.UserService.GetByOpenID:input_type -> hermes.v1.OpenIDRequest
-	2,  // 19: hermes.v1.UserService.GetByIdentity:input_type -> hermes.v1.GetByIdentityRequest
-	3,  // 20: hermes.v1.UserService.GetByEmail:input_type -> hermes.v1.GetByEmailRequest
-	4,  // 21: hermes.v1.UserService.GetByPhonePlain:input_type -> hermes.v1.GetByPhonePlainRequest
-	33, // 22: hermes.v1.UserService.GetDecryptedUser:input_type -> hermes.v1.OpenIDRequest
-	2,  // 23: hermes.v1.UserService.GetDecryptedUserByIdentity:input_type -> hermes.v1.GetByIdentityRequest
-	5,  // 24: hermes.v1.UserService.CreateUser:input_type -> hermes.v1.CreateUserRequest
-	7,  // 25: hermes.v1.UserService.UpdateUser:input_type -> hermes.v1.UpdateUserRequest
-	33, // 26: hermes.v1.UserService.UpdateLastLogin:input_type -> hermes.v1.OpenIDRequest
-	8,  // 27: hermes.v1.UserService.UpdatePassword:input_type -> hermes.v1.UpdatePasswordRequest
-	33, // 28: hermes.v1.UserService.GetIdentities:input_type -> hermes.v1.OpenIDRequest
-	2,  // 29: hermes.v1.UserService.GetIdentitiesByIdentity:input_type -> hermes.v1.GetByIdentityRequest
-	11, // 30: hermes.v1.UserService.GetIdentityByType:input_type -> hermes.v1.GetIdentityByTypeRequest
-	12, // 31: hermes.v1.UserService.AddIdentity:input_type -> hermes.v1.AddIdentityRequest
-	13, // 32: hermes.v1.UserService.GetUserByIdentifier:input_type -> hermes.v1.GetByIdentifierRequest
-	13, // 33: hermes.v1.UserService.GetStaffByIdentifier:input_type -> hermes.v1.GetByIdentifierRequest
-	18, // 34: hermes.v1.UserService.CreateCredential:input_type -> hermes.v1.CreateCredentialRequest
-	15, // 35: hermes.v1.UserService.GetCredentialByID:input_type -> hermes.v1.CredentialIDRequest
-	33, // 36: hermes.v1.UserService.GetUserCredentials:input_type -> hermes.v1.OpenIDRequest
-	19, // 37: hermes.v1.UserService.GetUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
-	19, // 38: hermes.v1.UserService.GetEnabledUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
-	20, // 39: hermes.v1.UserService.UpdateCredential:input_type -> hermes.v1.UpdateCredentialRequest
-	21, // 40: hermes.v1.UserService.UpdateCredentialSignCount:input_type -> hermes.v1.UpdateCredentialSignCountRequest
-	15, // 41: hermes.v1.UserService.EnableCredential:input_type -> hermes.v1.CredentialIDRequest
-	15, // 42: hermes.v1.UserService.DisableCredential:input_type -> hermes.v1.CredentialIDRequest
-	22, // 43: hermes.v1.UserService.DeleteCredential:input_type -> hermes.v1.DeleteCredentialRequest
-	15, // 44: hermes.v1.UserService.GetOpenIDByCredentialID:input_type -> hermes.v1.CredentialIDRequest
-	27, // 45: hermes.v1.UserService.CreateGroup:input_type -> hermes.v1.CreateGroupRequest
-	26, // 46: hermes.v1.UserService.GetGroup:input_type -> hermes.v1.GetGroupRequest
-	29, // 47: hermes.v1.UserService.ListGroups:input_type -> hermes.v1.ListGroupsRequest
-	28, // 48: hermes.v1.UserService.UpdateGroup:input_type -> hermes.v1.UpdateGroupRequest
-	26, // 49: hermes.v1.UserService.DeleteGroup:input_type -> hermes.v1.GetGroupRequest
-	30, // 50: hermes.v1.UserService.SetGroupMembers:input_type -> hermes.v1.SetGroupMembersRequest
-	26, // 51: hermes.v1.UserService.GetGroupMembers:input_type -> hermes.v1.GetGroupRequest
-	0,  // 52: hermes.v1.UserService.GetByOpenID:output_type -> hermes.v1.User
-	0,  // 53: hermes.v1.UserService.GetByIdentity:output_type -> hermes.v1.User
-	1,  // 54: hermes.v1.UserService.GetByEmail:output_type -> hermes.v1.DecryptedUser
-	1,  // 55: hermes.v1.UserService.GetByPhonePlain:output_type -> hermes.v1.DecryptedUser
-	1,  // 56: hermes.v1.UserService.GetDecryptedUser:output_type -> hermes.v1.DecryptedUser
-	1,  // 57: hermes.v1.UserService.GetDecryptedUserByIdentity:output_type -> hermes.v1.DecryptedUser
-	1,  // 58: hermes.v1.UserService.CreateUser:output_type -> hermes.v1.DecryptedUser
-	0,  // 59: hermes.v1.UserService.UpdateUser:output_type -> hermes.v1.User
-	34, // 60: hermes.v1.UserService.UpdateLastLogin:output_type -> google.protobuf.Empty
-	34, // 61: hermes.v1.UserService.UpdatePassword:output_type -> google.protobuf.Empty
-	10, // 62: hermes.v1.UserService.GetIdentities:output_type -> hermes.v1.IdentityList
-	10, // 63: hermes.v1.UserService.GetIdentitiesByIdentity:output_type -> hermes.v1.IdentityList
-	9,  // 64: hermes.v1.UserService.GetIdentityByType:output_type -> hermes.v1.UserIdentity
-	34, // 65: hermes.v1.UserService.AddIdentity:output_type -> google.protobuf.Empty
-	14, // 66: hermes.v1.UserService.GetUserByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
-	14, // 67: hermes.v1.UserService.GetStaffByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
-	34, // 68: hermes.v1.UserService.CreateCredential:output_type -> google.protobuf.Empty
-	16, // 69: hermes.v1.UserService.GetCredentialByID:output_type -> hermes.v1.UserCredential
-	17, // 70: hermes.v1.UserService.GetUserCredentials:output_type -> hermes.v1.UserCredentialList
-	17, // 71: hermes.v1.UserService.GetUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
-	17, // 72: hermes.v1.UserService.GetEnabledUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
-	34, // 73: hermes.v1.UserService.UpdateCredential:output_type -> google.protobuf.Empty
-	34, // 74: hermes.v1.UserService.UpdateCredentialSignCount:output_type -> google.protobuf.Empty
-	34, // 75: hermes.v1.UserService.EnableCredential:output_type -> google.protobuf.Empty
-	34, // 76: hermes.v1.UserService.DisableCredential:output_type -> google.protobuf.Empty
-	34, // 77: hermes.v1.UserService.DeleteCredential:output_type -> google.protobuf.Empty
-	23, // 78: hermes.v1.UserService.GetOpenIDByCredentialID:output_type -> hermes.v1.OpenIDResponse
-	24, // 79: hermes.v1.UserService.CreateGroup:output_type -> hermes.v1.Group
-	24, // 80: hermes.v1.UserService.GetGroup:output_type -> hermes.v1.Group
-	25, // 81: hermes.v1.UserService.ListGroups:output_type -> hermes.v1.GroupList
-	24, // 82: hermes.v1.UserService.UpdateGroup:output_type -> hermes.v1.Group
-	34, // 83: hermes.v1.UserService.DeleteGroup:output_type -> google.protobuf.Empty
-	34, // 84: hermes.v1.UserService.SetGroupMembers:output_type -> google.protobuf.Empty
-	35, // 85: hermes.v1.UserService.GetGroupMembers:output_type -> hermes.v1.StringList
-	52, // [52:86] is the sub-list for method output_type
-	18, // [18:52] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	33, // 13: hermes.v1.UpdateCredentialRequest.last_used_at:type_name -> google.protobuf.Timestamp
+	33, // 14: hermes.v1.UpdateCredentialByInternalIDRequest.last_used_at:type_name -> google.protobuf.Timestamp
+	33, // 15: hermes.v1.Group.created_at:type_name -> google.protobuf.Timestamp
+	33, // 16: hermes.v1.Group.updated_at:type_name -> google.protobuf.Timestamp
+	26, // 17: hermes.v1.GroupList.groups:type_name -> hermes.v1.Group
+	34, // 18: hermes.v1.ListGroupsRequest.pagination:type_name -> hermes.v1.Pagination
+	35, // 19: hermes.v1.UserService.GetByOpenID:input_type -> hermes.v1.OpenIDRequest
+	2,  // 20: hermes.v1.UserService.GetByIdentity:input_type -> hermes.v1.GetByIdentityRequest
+	3,  // 21: hermes.v1.UserService.GetByEmail:input_type -> hermes.v1.GetByEmailRequest
+	4,  // 22: hermes.v1.UserService.GetByPhonePlain:input_type -> hermes.v1.GetByPhonePlainRequest
+	35, // 23: hermes.v1.UserService.GetDecryptedUser:input_type -> hermes.v1.OpenIDRequest
+	2,  // 24: hermes.v1.UserService.GetDecryptedUserByIdentity:input_type -> hermes.v1.GetByIdentityRequest
+	5,  // 25: hermes.v1.UserService.CreateUser:input_type -> hermes.v1.CreateUserRequest
+	7,  // 26: hermes.v1.UserService.UpdateUser:input_type -> hermes.v1.UpdateUserRequest
+	35, // 27: hermes.v1.UserService.UpdateLastLogin:input_type -> hermes.v1.OpenIDRequest
+	8,  // 28: hermes.v1.UserService.UpdatePassword:input_type -> hermes.v1.UpdatePasswordRequest
+	35, // 29: hermes.v1.UserService.GetIdentities:input_type -> hermes.v1.OpenIDRequest
+	2,  // 30: hermes.v1.UserService.GetIdentitiesByIdentity:input_type -> hermes.v1.GetByIdentityRequest
+	11, // 31: hermes.v1.UserService.GetIdentityByType:input_type -> hermes.v1.GetIdentityByTypeRequest
+	12, // 32: hermes.v1.UserService.AddIdentity:input_type -> hermes.v1.AddIdentityRequest
+	13, // 33: hermes.v1.UserService.GetUserByIdentifier:input_type -> hermes.v1.GetByIdentifierRequest
+	13, // 34: hermes.v1.UserService.GetStaffByIdentifier:input_type -> hermes.v1.GetByIdentifierRequest
+	18, // 35: hermes.v1.UserService.CreateCredential:input_type -> hermes.v1.CreateCredentialRequest
+	15, // 36: hermes.v1.UserService.GetCredentialByID:input_type -> hermes.v1.CredentialIDRequest
+	35, // 37: hermes.v1.UserService.GetUserCredentials:input_type -> hermes.v1.OpenIDRequest
+	19, // 38: hermes.v1.UserService.GetUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
+	19, // 39: hermes.v1.UserService.GetEnabledUserCredentialsByType:input_type -> hermes.v1.GetCredentialsByTypeRequest
+	20, // 40: hermes.v1.UserService.UpdateCredential:input_type -> hermes.v1.UpdateCredentialRequest
+	21, // 41: hermes.v1.UserService.UpdateCredentialSignCount:input_type -> hermes.v1.UpdateCredentialSignCountRequest
+	15, // 42: hermes.v1.UserService.EnableCredential:input_type -> hermes.v1.CredentialIDRequest
+	15, // 43: hermes.v1.UserService.DisableCredential:input_type -> hermes.v1.CredentialIDRequest
+	22, // 44: hermes.v1.UserService.DeleteCredential:input_type -> hermes.v1.DeleteCredentialRequest
+	23, // 45: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:input_type -> hermes.v1.DeleteCredentialByTypeRequest
+	24, // 46: hermes.v1.UserService.UpdateCredentialByInternalID:input_type -> hermes.v1.UpdateCredentialByInternalIDRequest
+	15, // 47: hermes.v1.UserService.GetOpenIDByCredentialID:input_type -> hermes.v1.CredentialIDRequest
+	29, // 48: hermes.v1.UserService.CreateGroup:input_type -> hermes.v1.CreateGroupRequest
+	28, // 49: hermes.v1.UserService.GetGroup:input_type -> hermes.v1.GetGroupRequest
+	31, // 50: hermes.v1.UserService.ListGroups:input_type -> hermes.v1.ListGroupsRequest
+	30, // 51: hermes.v1.UserService.UpdateGroup:input_type -> hermes.v1.UpdateGroupRequest
+	28, // 52: hermes.v1.UserService.DeleteGroup:input_type -> hermes.v1.GetGroupRequest
+	32, // 53: hermes.v1.UserService.SetGroupMembers:input_type -> hermes.v1.SetGroupMembersRequest
+	28, // 54: hermes.v1.UserService.GetGroupMembers:input_type -> hermes.v1.GetGroupRequest
+	0,  // 55: hermes.v1.UserService.GetByOpenID:output_type -> hermes.v1.User
+	0,  // 56: hermes.v1.UserService.GetByIdentity:output_type -> hermes.v1.User
+	1,  // 57: hermes.v1.UserService.GetByEmail:output_type -> hermes.v1.DecryptedUser
+	1,  // 58: hermes.v1.UserService.GetByPhonePlain:output_type -> hermes.v1.DecryptedUser
+	1,  // 59: hermes.v1.UserService.GetDecryptedUser:output_type -> hermes.v1.DecryptedUser
+	1,  // 60: hermes.v1.UserService.GetDecryptedUserByIdentity:output_type -> hermes.v1.DecryptedUser
+	1,  // 61: hermes.v1.UserService.CreateUser:output_type -> hermes.v1.DecryptedUser
+	0,  // 62: hermes.v1.UserService.UpdateUser:output_type -> hermes.v1.User
+	36, // 63: hermes.v1.UserService.UpdateLastLogin:output_type -> google.protobuf.Empty
+	36, // 64: hermes.v1.UserService.UpdatePassword:output_type -> google.protobuf.Empty
+	10, // 65: hermes.v1.UserService.GetIdentities:output_type -> hermes.v1.IdentityList
+	10, // 66: hermes.v1.UserService.GetIdentitiesByIdentity:output_type -> hermes.v1.IdentityList
+	9,  // 67: hermes.v1.UserService.GetIdentityByType:output_type -> hermes.v1.UserIdentity
+	36, // 68: hermes.v1.UserService.AddIdentity:output_type -> google.protobuf.Empty
+	14, // 69: hermes.v1.UserService.GetUserByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
+	14, // 70: hermes.v1.UserService.GetStaffByIdentifier:output_type -> hermes.v1.PasswordStoreCredential
+	36, // 71: hermes.v1.UserService.CreateCredential:output_type -> google.protobuf.Empty
+	16, // 72: hermes.v1.UserService.GetCredentialByID:output_type -> hermes.v1.UserCredential
+	17, // 73: hermes.v1.UserService.GetUserCredentials:output_type -> hermes.v1.UserCredentialList
+	17, // 74: hermes.v1.UserService.GetUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
+	17, // 75: hermes.v1.UserService.GetEnabledUserCredentialsByType:output_type -> hermes.v1.UserCredentialList
+	36, // 76: hermes.v1.UserService.UpdateCredential:output_type -> google.protobuf.Empty
+	36, // 77: hermes.v1.UserService.UpdateCredentialSignCount:output_type -> google.protobuf.Empty
+	36, // 78: hermes.v1.UserService.EnableCredential:output_type -> google.protobuf.Empty
+	36, // 79: hermes.v1.UserService.DisableCredential:output_type -> google.protobuf.Empty
+	36, // 80: hermes.v1.UserService.DeleteCredential:output_type -> google.protobuf.Empty
+	36, // 81: hermes.v1.UserService.DeleteCredentialByOpenIDAndType:output_type -> google.protobuf.Empty
+	36, // 82: hermes.v1.UserService.UpdateCredentialByInternalID:output_type -> google.protobuf.Empty
+	25, // 83: hermes.v1.UserService.GetOpenIDByCredentialID:output_type -> hermes.v1.OpenIDResponse
+	26, // 84: hermes.v1.UserService.CreateGroup:output_type -> hermes.v1.Group
+	26, // 85: hermes.v1.UserService.GetGroup:output_type -> hermes.v1.Group
+	27, // 86: hermes.v1.UserService.ListGroups:output_type -> hermes.v1.GroupList
+	26, // 87: hermes.v1.UserService.UpdateGroup:output_type -> hermes.v1.Group
+	36, // 88: hermes.v1.UserService.DeleteGroup:output_type -> google.protobuf.Empty
+	36, // 89: hermes.v1.UserService.SetGroupMembers:output_type -> google.protobuf.Empty
+	37, // 90: hermes.v1.UserService.GetGroupMembers:output_type -> hermes.v1.StringList
+	55, // [55:91] is the sub-list for method output_type
+	19, // [19:55] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_hermes_v1_user_proto_init() }
@@ -2381,15 +2523,16 @@ func file_hermes_v1_user_proto_init() {
 	file_hermes_v1_user_proto_msgTypes[18].OneofWrappers = []any{}
 	file_hermes_v1_user_proto_msgTypes[20].OneofWrappers = []any{}
 	file_hermes_v1_user_proto_msgTypes[24].OneofWrappers = []any{}
-	file_hermes_v1_user_proto_msgTypes[27].OneofWrappers = []any{}
-	file_hermes_v1_user_proto_msgTypes[28].OneofWrappers = []any{}
+	file_hermes_v1_user_proto_msgTypes[26].OneofWrappers = []any{}
+	file_hermes_v1_user_proto_msgTypes[29].OneofWrappers = []any{}
+	file_hermes_v1_user_proto_msgTypes[30].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_hermes_v1_user_proto_rawDesc), len(file_hermes_v1_user_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/hermes/v1/user_grpc.pb.go
+++ b/gen/proto/hermes/v1/user_grpc.pb.go
@@ -40,11 +40,8 @@ const (
 	UserService_GetCredentialByID_FullMethodName               = "/hermes.v1.UserService/GetCredentialByID"
 	UserService_GetUserCredentials_FullMethodName              = "/hermes.v1.UserService/GetUserCredentials"
 	UserService_GetUserCredentialsByType_FullMethodName        = "/hermes.v1.UserService/GetUserCredentialsByType"
-	UserService_GetEnabledUserCredentialsByType_FullMethodName = "/hermes.v1.UserService/GetEnabledUserCredentialsByType"
 	UserService_UpdateCredential_FullMethodName                = "/hermes.v1.UserService/UpdateCredential"
 	UserService_UpdateCredentialSignCount_FullMethodName       = "/hermes.v1.UserService/UpdateCredentialSignCount"
-	UserService_EnableCredential_FullMethodName                = "/hermes.v1.UserService/EnableCredential"
-	UserService_DisableCredential_FullMethodName               = "/hermes.v1.UserService/DisableCredential"
 	UserService_DeleteCredential_FullMethodName                = "/hermes.v1.UserService/DeleteCredential"
 	UserService_DeleteCredentialByOpenIDAndType_FullMethodName = "/hermes.v1.UserService/DeleteCredentialByOpenIDAndType"
 	UserService_UpdateCredentialByInternalID_FullMethodName    = "/hermes.v1.UserService/UpdateCredentialByInternalID"
@@ -84,11 +81,8 @@ type UserServiceClient interface {
 	GetCredentialByID(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*UserCredential, error)
 	GetUserCredentials(ctx context.Context, in *OpenIDRequest, opts ...grpc.CallOption) (*UserCredentialList, error)
 	GetUserCredentialsByType(ctx context.Context, in *GetCredentialsByTypeRequest, opts ...grpc.CallOption) (*UserCredentialList, error)
-	GetEnabledUserCredentialsByType(ctx context.Context, in *GetCredentialsByTypeRequest, opts ...grpc.CallOption) (*UserCredentialList, error)
 	UpdateCredential(ctx context.Context, in *UpdateCredentialRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	UpdateCredentialSignCount(ctx context.Context, in *UpdateCredentialSignCountRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	EnableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	DisableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	DeleteCredential(ctx context.Context, in *DeleteCredentialRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	DeleteCredentialByOpenIDAndType(ctx context.Context, in *DeleteCredentialByTypeRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	UpdateCredentialByInternalID(ctx context.Context, in *UpdateCredentialByInternalIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -310,16 +304,6 @@ func (c *userServiceClient) GetUserCredentialsByType(ctx context.Context, in *Ge
 	return out, nil
 }
 
-func (c *userServiceClient) GetEnabledUserCredentialsByType(ctx context.Context, in *GetCredentialsByTypeRequest, opts ...grpc.CallOption) (*UserCredentialList, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(UserCredentialList)
-	err := c.cc.Invoke(ctx, UserService_GetEnabledUserCredentialsByType_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *userServiceClient) UpdateCredential(ctx context.Context, in *UpdateCredentialRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
@@ -334,26 +318,6 @@ func (c *userServiceClient) UpdateCredentialSignCount(ctx context.Context, in *U
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, UserService_UpdateCredentialSignCount_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *userServiceClient) EnableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(emptypb.Empty)
-	err := c.cc.Invoke(ctx, UserService_EnableCredential_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *userServiceClient) DisableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(emptypb.Empty)
-	err := c.cc.Invoke(ctx, UserService_DisableCredential_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -496,11 +460,8 @@ type UserServiceServer interface {
 	GetCredentialByID(context.Context, *CredentialIDRequest) (*UserCredential, error)
 	GetUserCredentials(context.Context, *OpenIDRequest) (*UserCredentialList, error)
 	GetUserCredentialsByType(context.Context, *GetCredentialsByTypeRequest) (*UserCredentialList, error)
-	GetEnabledUserCredentialsByType(context.Context, *GetCredentialsByTypeRequest) (*UserCredentialList, error)
 	UpdateCredential(context.Context, *UpdateCredentialRequest) (*emptypb.Empty, error)
 	UpdateCredentialSignCount(context.Context, *UpdateCredentialSignCountRequest) (*emptypb.Empty, error)
-	EnableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error)
-	DisableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error)
 	DeleteCredential(context.Context, *DeleteCredentialRequest) (*emptypb.Empty, error)
 	DeleteCredentialByOpenIDAndType(context.Context, *DeleteCredentialByTypeRequest) (*emptypb.Empty, error)
 	UpdateCredentialByInternalID(context.Context, *UpdateCredentialByInternalIDRequest) (*emptypb.Empty, error)
@@ -582,20 +543,11 @@ func (UnimplementedUserServiceServer) GetUserCredentials(context.Context, *OpenI
 func (UnimplementedUserServiceServer) GetUserCredentialsByType(context.Context, *GetCredentialsByTypeRequest) (*UserCredentialList, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetUserCredentialsByType not implemented")
 }
-func (UnimplementedUserServiceServer) GetEnabledUserCredentialsByType(context.Context, *GetCredentialsByTypeRequest) (*UserCredentialList, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetEnabledUserCredentialsByType not implemented")
-}
 func (UnimplementedUserServiceServer) UpdateCredential(context.Context, *UpdateCredentialRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateCredential not implemented")
 }
 func (UnimplementedUserServiceServer) UpdateCredentialSignCount(context.Context, *UpdateCredentialSignCountRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateCredentialSignCount not implemented")
-}
-func (UnimplementedUserServiceServer) EnableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "method EnableCredential not implemented")
-}
-func (UnimplementedUserServiceServer) DisableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "method DisableCredential not implemented")
 }
 func (UnimplementedUserServiceServer) DeleteCredential(context.Context, *DeleteCredentialRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteCredential not implemented")
@@ -1011,24 +963,6 @@ func _UserService_GetUserCredentialsByType_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UserService_GetEnabledUserCredentialsByType_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetCredentialsByTypeRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(UserServiceServer).GetEnabledUserCredentialsByType(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: UserService_GetEnabledUserCredentialsByType_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserServiceServer).GetEnabledUserCredentialsByType(ctx, req.(*GetCredentialsByTypeRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _UserService_UpdateCredential_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateCredentialRequest)
 	if err := dec(in); err != nil {
@@ -1061,42 +995,6 @@ func _UserService_UpdateCredentialSignCount_Handler(srv interface{}, ctx context
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(UserServiceServer).UpdateCredentialSignCount(ctx, req.(*UpdateCredentialSignCountRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _UserService_EnableCredential_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialIDRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(UserServiceServer).EnableCredential(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: UserService_EnableCredential_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserServiceServer).EnableCredential(ctx, req.(*CredentialIDRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _UserService_DisableCredential_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialIDRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(UserServiceServer).DisableCredential(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: UserService_DisableCredential_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserServiceServer).DisableCredential(ctx, req.(*CredentialIDRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1387,24 +1285,12 @@ var UserService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _UserService_GetUserCredentialsByType_Handler,
 		},
 		{
-			MethodName: "GetEnabledUserCredentialsByType",
-			Handler:    _UserService_GetEnabledUserCredentialsByType_Handler,
-		},
-		{
 			MethodName: "UpdateCredential",
 			Handler:    _UserService_UpdateCredential_Handler,
 		},
 		{
 			MethodName: "UpdateCredentialSignCount",
 			Handler:    _UserService_UpdateCredentialSignCount_Handler,
-		},
-		{
-			MethodName: "EnableCredential",
-			Handler:    _UserService_EnableCredential_Handler,
-		},
-		{
-			MethodName: "DisableCredential",
-			Handler:    _UserService_DisableCredential_Handler,
 		},
 		{
 			MethodName: "DeleteCredential",

--- a/gen/proto/hermes/v1/user_grpc.pb.go
+++ b/gen/proto/hermes/v1/user_grpc.pb.go
@@ -46,6 +46,8 @@ const (
 	UserService_EnableCredential_FullMethodName                = "/hermes.v1.UserService/EnableCredential"
 	UserService_DisableCredential_FullMethodName               = "/hermes.v1.UserService/DisableCredential"
 	UserService_DeleteCredential_FullMethodName                = "/hermes.v1.UserService/DeleteCredential"
+	UserService_DeleteCredentialByOpenIDAndType_FullMethodName = "/hermes.v1.UserService/DeleteCredentialByOpenIDAndType"
+	UserService_UpdateCredentialByInternalID_FullMethodName    = "/hermes.v1.UserService/UpdateCredentialByInternalID"
 	UserService_GetOpenIDByCredentialID_FullMethodName         = "/hermes.v1.UserService/GetOpenIDByCredentialID"
 	UserService_CreateGroup_FullMethodName                     = "/hermes.v1.UserService/CreateGroup"
 	UserService_GetGroup_FullMethodName                        = "/hermes.v1.UserService/GetGroup"
@@ -88,6 +90,8 @@ type UserServiceClient interface {
 	EnableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	DisableCredential(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	DeleteCredential(ctx context.Context, in *DeleteCredentialRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeleteCredentialByOpenIDAndType(ctx context.Context, in *DeleteCredentialByTypeRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	UpdateCredentialByInternalID(ctx context.Context, in *UpdateCredentialByInternalIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	GetOpenIDByCredentialID(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*OpenIDResponse, error)
 	CreateGroup(ctx context.Context, in *CreateGroupRequest, opts ...grpc.CallOption) (*Group, error)
 	GetGroup(ctx context.Context, in *GetGroupRequest, opts ...grpc.CallOption) (*Group, error)
@@ -366,6 +370,26 @@ func (c *userServiceClient) DeleteCredential(ctx context.Context, in *DeleteCred
 	return out, nil
 }
 
+func (c *userServiceClient) DeleteCredentialByOpenIDAndType(ctx context.Context, in *DeleteCredentialByTypeRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, UserService_DeleteCredentialByOpenIDAndType_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userServiceClient) UpdateCredentialByInternalID(ctx context.Context, in *UpdateCredentialByInternalIDRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, UserService_UpdateCredentialByInternalID_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *userServiceClient) GetOpenIDByCredentialID(ctx context.Context, in *CredentialIDRequest, opts ...grpc.CallOption) (*OpenIDResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(OpenIDResponse)
@@ -478,6 +502,8 @@ type UserServiceServer interface {
 	EnableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error)
 	DisableCredential(context.Context, *CredentialIDRequest) (*emptypb.Empty, error)
 	DeleteCredential(context.Context, *DeleteCredentialRequest) (*emptypb.Empty, error)
+	DeleteCredentialByOpenIDAndType(context.Context, *DeleteCredentialByTypeRequest) (*emptypb.Empty, error)
+	UpdateCredentialByInternalID(context.Context, *UpdateCredentialByInternalIDRequest) (*emptypb.Empty, error)
 	GetOpenIDByCredentialID(context.Context, *CredentialIDRequest) (*OpenIDResponse, error)
 	CreateGroup(context.Context, *CreateGroupRequest) (*Group, error)
 	GetGroup(context.Context, *GetGroupRequest) (*Group, error)
@@ -573,6 +599,12 @@ func (UnimplementedUserServiceServer) DisableCredential(context.Context, *Creden
 }
 func (UnimplementedUserServiceServer) DeleteCredential(context.Context, *DeleteCredentialRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteCredential not implemented")
+}
+func (UnimplementedUserServiceServer) DeleteCredentialByOpenIDAndType(context.Context, *DeleteCredentialByTypeRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteCredentialByOpenIDAndType not implemented")
+}
+func (UnimplementedUserServiceServer) UpdateCredentialByInternalID(context.Context, *UpdateCredentialByInternalIDRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateCredentialByInternalID not implemented")
 }
 func (UnimplementedUserServiceServer) GetOpenIDByCredentialID(context.Context, *CredentialIDRequest) (*OpenIDResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetOpenIDByCredentialID not implemented")
@@ -1087,6 +1119,42 @@ func _UserService_DeleteCredential_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UserService_DeleteCredentialByOpenIDAndType_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteCredentialByTypeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).DeleteCredentialByOpenIDAndType(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_DeleteCredentialByOpenIDAndType_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).DeleteCredentialByOpenIDAndType(ctx, req.(*DeleteCredentialByTypeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserService_UpdateCredentialByInternalID_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateCredentialByInternalIDRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).UpdateCredentialByInternalID(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_UpdateCredentialByInternalID_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).UpdateCredentialByInternalID(ctx, req.(*UpdateCredentialByInternalIDRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _UserService_GetOpenIDByCredentialID_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CredentialIDRequest)
 	if err := dec(in); err != nil {
@@ -1341,6 +1409,14 @@ var UserService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteCredential",
 			Handler:    _UserService_DeleteCredential_Handler,
+		},
+		{
+			MethodName: "DeleteCredentialByOpenIDAndType",
+			Handler:    _UserService_DeleteCredentialByOpenIDAndType_Handler,
+		},
+		{
+			MethodName: "UpdateCredentialByInternalID",
+			Handler:    _UserService_UpdateCredentialByInternalID_Handler,
 		},
 		{
 			MethodName: "GetOpenIDByCredentialID",

--- a/hermes/dto/provision.go
+++ b/hermes/dto/provision.go
@@ -13,7 +13,7 @@ type DomainUpdateRequest struct {
 	Description patch.Optional[string] `json:"description"`
 }
 
-// DomainResponse 域基础信息（名称、描述等）；allowed_idps 不在此暴露，需时调 GET /domains/:id/idps）
+// DomainResponse 域基础信息（名称、描述等）；IDP 配置通过 GET /domains/:id/idp-configs 获取
 type DomainResponse struct {
 	DomainID    string  `json:"domain_id"`
 	Name        string  `json:"name"`
@@ -175,7 +175,43 @@ func NewDomainIDPConfigResponse(c *models.DomainIDPConfig) DomainIDPConfigRespon
 	}
 }
 
-// ApplicationIDPConfigCreateRequest 创建应用 IDP 配置请求（idp 类型必须在应用所属域的 allowed_idps 内）
+// ==================== Service Challenge Setting ====================
+
+// ServiceChallengeSettingCreateRequest 创建服务 Challenge 配置请求
+type ServiceChallengeSettingCreateRequest struct {
+	Type      string            `json:"type" binding:"required"`
+	ExpiresIn uint              `json:"expires_in"`
+	Limits    models.RateLimits `json:"limits"`
+}
+
+// ServiceChallengeSettingUpdateRequest 更新服务 Challenge 配置请求（JSON Merge Patch 语义）
+type ServiceChallengeSettingUpdateRequest struct {
+	ExpiresIn patch.Optional[uint]              `json:"expires_in"`
+	Limits    patch.Optional[models.RateLimits] `json:"limits"`
+}
+
+// ServiceChallengeSettingResponse 服务 Challenge 配置
+type ServiceChallengeSettingResponse struct {
+	ServiceID string            `json:"service_id"`
+	Type      string            `json:"type"`
+	ExpiresIn uint              `json:"expires_in"`
+	Limits    models.RateLimits `json:"limits,omitempty"`
+	CreatedAt string            `json:"created_at"`
+	UpdatedAt string            `json:"updated_at"`
+}
+
+func NewServiceChallengeSettingResponse(s *models.ServiceChallengeSetting) ServiceChallengeSettingResponse {
+	return ServiceChallengeSettingResponse{
+		ServiceID: s.ServiceID,
+		Type:      s.Type,
+		ExpiresIn: s.ExpiresIn,
+		Limits:    s.Limits,
+		CreatedAt: FormatTime(s.CreatedAt),
+		UpdatedAt: FormatTime(s.UpdatedAt),
+	}
+}
+
+// ApplicationIDPConfigCreateRequest 创建应用 IDP 配置请求（idp 类型必须在应用所属域的 idp-configs 内）
 type ApplicationIDPConfigCreateRequest struct {
 	Type     string  `json:"type" binding:"required"`
 	Priority int     `json:"priority"`

--- a/hermes/grpc/user_service.go
+++ b/hermes/grpc/user_service.go
@@ -208,11 +208,11 @@ func (s *userServiceServer) CreateCredential(ctx context.Context, req *hermesv1.
 	cred := &models.UserCredential{
 		OpenID:  req.GetOpenid(),
 		Type:    req.GetType(),
-		Enabled: req.GetEnabled(),
+		Enabled: true,
 		Secret:  req.GetSecret(),
 	}
-	if req.CredentialId != nil {
-		cred.CredentialID = req.CredentialId
+	if id := req.GetCredentialId(); id != "" {
+		cred.CredentialID = &id
 	}
 	if err := s.svc.CreateCredential(ctx, cred); err != nil {
 		return nil, toStatus(err)
@@ -244,19 +244,8 @@ func (s *userServiceServer) GetUserCredentialsByType(ctx context.Context, req *h
 	return userCredentialListToProto(creds), nil
 }
 
-func (s *userServiceServer) GetEnabledUserCredentialsByType(ctx context.Context, req *hermesv1.GetCredentialsByTypeRequest) (*hermesv1.UserCredentialList, error) {
-	creds, err := s.svc.GetEnabledUserCredentialsByType(ctx, req.GetOpenid(), req.GetType())
-	if err != nil {
-		return nil, toStatus(err)
-	}
-	return userCredentialListToProto(creds), nil
-}
-
 func (s *userServiceServer) UpdateCredential(ctx context.Context, req *hermesv1.UpdateCredentialRequest) (*emptypb.Empty, error) {
 	updates := make(map[string]any)
-	if req.Enabled != nil {
-		updates["enabled"] = *req.Enabled
-	}
 	if req.Secret != nil {
 		updates["secret"] = *req.Secret
 	}
@@ -274,20 +263,6 @@ func (s *userServiceServer) UpdateCredential(ctx context.Context, req *hermesv1.
 
 func (s *userServiceServer) UpdateCredentialSignCount(ctx context.Context, req *hermesv1.UpdateCredentialSignCountRequest) (*emptypb.Empty, error) {
 	if err := s.svc.UpdateCredentialSignCount(ctx, req.GetCredentialId(), req.GetSignCount()); err != nil {
-		return nil, toStatus(err)
-	}
-	return &emptypb.Empty{}, nil
-}
-
-func (s *userServiceServer) EnableCredential(ctx context.Context, req *hermesv1.CredentialIDRequest) (*emptypb.Empty, error) {
-	if err := s.svc.EnableCredential(ctx, req.GetCredentialId()); err != nil {
-		return nil, toStatus(err)
-	}
-	return &emptypb.Empty{}, nil
-}
-
-func (s *userServiceServer) DisableCredential(ctx context.Context, req *hermesv1.CredentialIDRequest) (*emptypb.Empty, error) {
-	if err := s.svc.DisableCredential(ctx, req.GetCredentialId()); err != nil {
 		return nil, toStatus(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -484,13 +459,24 @@ func passwordStoreCredentialToProto(c *dto.PasswordStoreCredential) *hermesv1.Pa
 	return pb
 }
 
+// credentialProtoEnabled 与 Iris MFA 语义对齐：TOTP 待确认阶段无 last_used_at，已绑定则有
+func credentialProtoEnabled(c *models.UserCredential) bool {
+	if c.Type == string(models.CredentialTypeTOTP) {
+		if c.LastUsedAt != nil {
+			return true
+		}
+		return c.Enabled
+	}
+	return c.Enabled
+}
+
 func userCredentialToProto(c *models.UserCredential) *hermesv1.UserCredential {
 	pb := &hermesv1.UserCredential{
 		Id:           safeUint32(c.ID),
 		Openid:       c.OpenID,
 		CredentialId: c.CredentialID,
 		Type:         c.Type,
-		Enabled:      c.Enabled,
+		Enabled:      credentialProtoEnabled(c),
 		Secret:       c.Secret,
 		CreatedAt:    timestamppb.New(c.CreatedAt),
 		UpdatedAt:    timestamppb.New(c.UpdatedAt),

--- a/hermes/grpc/user_service.go
+++ b/hermes/grpc/user_service.go
@@ -300,6 +300,30 @@ func (s *userServiceServer) DeleteCredential(ctx context.Context, req *hermesv1.
 	return &emptypb.Empty{}, nil
 }
 
+func (s *userServiceServer) DeleteCredentialByOpenIDAndType(ctx context.Context, req *hermesv1.DeleteCredentialByTypeRequest) (*emptypb.Empty, error) {
+	if err := s.svc.DeleteCredentialByOpenIDAndType(ctx, req.GetOpenid(), req.GetType()); err != nil {
+		return nil, toStatus(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *userServiceServer) UpdateCredentialByInternalID(ctx context.Context, req *hermesv1.UpdateCredentialByInternalIDRequest) (*emptypb.Empty, error) {
+	updates := make(map[string]any)
+	if req.Enabled != nil {
+		updates["enabled"] = req.GetEnabled()
+	}
+	if req.Secret != nil {
+		updates["secret"] = req.GetSecret()
+	}
+	if req.LastUsedAt != nil {
+		updates["last_used_at"] = req.GetLastUsedAt().AsTime()
+	}
+	if err := s.svc.UpdateCredentialByInternalID(ctx, uint(req.GetId()), updates); err != nil {
+		return nil, toStatus(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
 func (s *userServiceServer) GetOpenIDByCredentialID(ctx context.Context, req *hermesv1.CredentialIDRequest) (*hermesv1.OpenIDResponse, error) {
 	openid, err := s.svc.GetOpenIDByCredentialID(ctx, req.GetCredentialId())
 	if err != nil {
@@ -467,6 +491,7 @@ func userCredentialToProto(c *models.UserCredential) *hermesv1.UserCredential {
 		CredentialId: c.CredentialID,
 		Type:         c.Type,
 		Enabled:      c.Enabled,
+		Secret:       c.Secret,
 		CreatedAt:    timestamppb.New(c.CreatedAt),
 		UpdatedAt:    timestamppb.New(c.UpdatedAt),
 	}

--- a/hermes/handler.go
+++ b/hermes/handler.go
@@ -39,17 +39,6 @@ func (h *Handler) GetDomain(c *gin.Context) {
 	})
 }
 
-// GetDomainAllowedIDPs GET /hermes/domains/:domain_id/idps（供配置应用 IDP 时按需拉取）
-func (h *Handler) GetDomainAllowedIDPs(c *gin.Context) {
-	domainID := c.Param("domain_id")
-	idps, err := h.service.GetDomainAllowedIDPs(c.Request.Context(), domainID)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"allowed_idps": idps})
-}
-
 // ==================== IDP Secret 相关 ====================
 
 // ListIDPKeys GET /hermes/idp-keys
@@ -117,7 +106,7 @@ func (h *Handler) DeleteIDPKey(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.Status(http.StatusNoContent)
 }
 
 // ==================== Domain IDP Config 相关 ====================
@@ -189,7 +178,7 @@ func (h *Handler) DeleteDomainIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.Status(http.StatusNoContent)
 }
 
 // UpdateDomain PATCH /hermes/domains/:domain_id（仅 name、description 可编辑）
@@ -327,7 +316,7 @@ func (h *Handler) DeleteService(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.Status(http.StatusNoContent)
 }
 
 // GetServiceApplicationRelations GET /hermes/domains/:domain_id/services/:service_id/applications
@@ -601,7 +590,7 @@ func (h *Handler) DeleteApplicationIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.Status(http.StatusNoContent)
 }
 
 // GetApplicationServiceRelations GET /hermes/domains/:domain_id/applications/:app_id/relations
@@ -632,6 +621,106 @@ func (h *Handler) GetApplicationServiceRelations(c *gin.Context) {
 		resp = append(resp, dto.ApplicationServiceRelationResponse{ServiceID: sid, Relations: rels})
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// DeleteDomain DELETE /hermes/domains/:domain_id
+func (h *Handler) DeleteDomain(c *gin.Context) {
+	domainID := c.Param("domain_id")
+	if err := h.service.DeleteDomain(c.Request.Context(), domainID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// DeleteApplication DELETE /hermes/domains/:domain_id/applications/:app_id
+func (h *Handler) DeleteApplication(c *gin.Context) {
+	domainID := c.Param("domain_id")
+	appID := c.Param("app_id")
+	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	if app.DomainID != domainID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "application not found in this domain"})
+		return
+	}
+	if err := h.service.DeleteApplication(c.Request.Context(), appID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// DeleteGroup DELETE /hermes/groups/:group_id
+func (h *Handler) DeleteGroup(c *gin.Context) {
+	groupID := c.Param("group_id")
+	if err := h.service.DeleteGroup(c.Request.Context(), groupID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ==================== Service Challenge Setting 相关 ====================
+
+// ListServiceChallengeSettings GET /hermes/domains/:domain_id/services/:service_id/challenge-settings
+func (h *Handler) ListServiceChallengeSettings(c *gin.Context) {
+	serviceID := c.Param("service_id")
+	settings, err := h.service.ListServiceChallengeSettings(c.Request.Context(), serviceID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resp := make([]dto.ServiceChallengeSettingResponse, 0, len(settings))
+	for i := range settings {
+		resp = append(resp, dto.NewServiceChallengeSettingResponse(&settings[i]))
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// CreateServiceChallengeSetting POST /hermes/domains/:domain_id/services/:service_id/challenge-settings
+func (h *Handler) CreateServiceChallengeSetting(c *gin.Context) {
+	serviceID := c.Param("service_id")
+	var req dto.ServiceChallengeSettingCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	setting, err := h.service.CreateServiceChallengeSetting(c.Request.Context(), serviceID, &req)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, dto.NewServiceChallengeSettingResponse(setting))
+}
+
+// UpdateServiceChallengeSetting PATCH /hermes/domains/:domain_id/services/:service_id/challenge-settings/:type
+func (h *Handler) UpdateServiceChallengeSetting(c *gin.Context) {
+	serviceID := c.Param("service_id")
+	challengeType := c.Param("type")
+	var req dto.ServiceChallengeSettingUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.service.UpdateServiceChallengeSetting(c.Request.Context(), serviceID, challengeType, &req); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "更新成功"})
+}
+
+// DeleteServiceChallengeSetting DELETE /hermes/domains/:domain_id/services/:service_id/challenge-settings/:type
+func (h *Handler) DeleteServiceChallengeSetting(c *gin.Context) {
+	serviceID := c.Param("service_id")
+	challengeType := c.Param("type")
+	if err := h.service.DeleteServiceChallengeSetting(c.Request.Context(), serviceID, challengeType); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 // ==================== Relationship 相关 ====================

--- a/hermes/key.go
+++ b/hermes/key.go
@@ -35,25 +35,6 @@ func generateEncryptedKey(aad string) (string, error) {
 	return base64.StdEncoding.EncodeToString(encryptedKey), nil
 }
 
-// GetDomainWithKey 获取域（含签名密钥，供 aegis 签发/验签）
-func (s *Service) GetDomainWithKey(ctx context.Context, domainID string) (*models.DomainWithKey, error) {
-	domain, err := s.getDomainFromDB(ctx, domainID)
-	if err != nil {
-		return nil, err
-	}
-
-	signKeys, err := s.GetDomainKeys(ctx, domainID)
-	if err != nil {
-		return nil, fmt.Errorf("获取域密钥失败: %w", err)
-	}
-
-	return &models.DomainWithKey{
-		Domain: *domain,
-		Main:   signKeys[0],
-		Keys:   signKeys,
-	}, nil
-}
-
 // GetDomainKeys 获取域的所有有效密钥（已解密），回退到配置文件兼容旧部署
 func (s *Service) GetDomainKeys(ctx context.Context, domainID string) ([][]byte, error) {
 	keys, err := s.getKeys(ctx, models.KeyOwnerDomain, domainID)
@@ -77,40 +58,6 @@ func (s *Service) GetApplicationKeys(ctx context.Context, appID string) ([][]byt
 // GetServiceKeys 获取服务的所有有效密钥（已解密）
 func (s *Service) GetServiceKeys(ctx context.Context, serviceID string) ([][]byte, error) {
 	return s.getKeys(ctx, models.KeyOwnerService, serviceID)
-}
-
-// GetServiceWithKey 获取服务（含解密密钥）
-func (s *Service) GetServiceWithKey(ctx context.Context, serviceID string) (*models.ServiceWithKey, error) {
-	var svc models.Service
-	if err := s.db.WithContext(ctx).Where("service_id = ?", serviceID).First(&svc).Error; err != nil {
-		return nil, fmt.Errorf("获取服务失败: %w", err)
-	}
-	keys, err := s.GetServiceKeys(ctx, serviceID)
-	if err != nil {
-		return nil, err
-	}
-	result := &models.ServiceWithKey{Service: svc, Keys: keys}
-	if len(keys) > 0 {
-		result.Main = keys[0]
-	}
-	return result, nil
-}
-
-// GetApplicationWithKey 获取应用（含解密密钥）
-func (s *Service) GetApplicationWithKey(ctx context.Context, appID string) (*models.ApplicationWithKey, error) {
-	var app models.Application
-	if err := s.db.WithContext(ctx).Where("app_id = ?", appID).First(&app).Error; err != nil {
-		return nil, fmt.Errorf("获取应用失败: %w", err)
-	}
-	keys, err := s.GetApplicationKeys(ctx, appID)
-	if err != nil {
-		return nil, err
-	}
-	result := &models.ApplicationWithKey{Application: app, Keys: keys}
-	if len(keys) > 0 {
-		result.Main = keys[0]
-	}
-	return result, nil
 }
 
 // RotateKey 轮换密钥：给旧主密钥设 expired_at，插入新密钥

--- a/hermes/models/application.go
+++ b/hermes/models/application.go
@@ -36,13 +36,6 @@ func (Application) TableName() string { return "t_application" }
 
 func (a Application) PrimaryKey() uint { return a.ID }
 
-// ApplicationWithKey 带密钥的 Application（Main/Keys 不序列化到 API）
-type ApplicationWithKey struct {
-	Application
-	Main []byte   `json:"-"` // 当前主密钥（48 字节 seed）
-	Keys [][]byte `json:"-"` // 所有有效密钥（包括主密钥和轮换中的旧密钥）
-}
-
 // ApplicationIDPConfig 应用 IDP 配置 + 可选凭证覆盖
 type ApplicationIDPConfig struct {
 	ID        uint      `gorm:"primaryKey;autoIncrement;column:_id" json:"_id"`

--- a/hermes/models/domain.go
+++ b/hermes/models/domain.go
@@ -2,19 +2,11 @@ package models
 
 import "time"
 
-// Domain 域（元数据与允许的 IDP 来自数据库，签名密钥来自配置/密钥服务）
+// Domain 域（元数据来自 t_domain，允许的 IDP 从 t_domain_idp_config 派生）
 type Domain struct {
-	DomainID    string   `json:"domain_id"`    // 域标识：consumer/platform
-	Name        string   `json:"name"`         // 域名称
-	Description *string  `json:"description"`  // 域描述
-	AllowedIDPs []string `json:"allowed_idps"` // 该域允许的 IDP 类型，应用添加 IDP 时只能从此列表选
-}
-
-// DomainWithKey 带签名密钥的 Domain（Main/Keys 不序列化到 API）
-type DomainWithKey struct {
-	Domain
-	Main []byte   `json:"-"` // 当前主密钥（48 字节 seed，用于签发新 token）
-	Keys [][]byte `json:"-"` // 所有有效密钥（包括主密钥和轮换中的旧密钥，用于验证）
+	DomainID    string  `json:"domain_id"`   // 域标识：consumer/platform
+	Name        string  `json:"name"`        // 域名称
+	Description *string `json:"description"` // 域描述
 }
 
 // DomainRecord 域表（t_domain）持久化模型
@@ -28,17 +20,8 @@ type DomainRecord struct {
 
 func (DomainRecord) TableName() string { return "t_domain" }
 
-// DomainIDPRecord 域允许的 IDP 表（t_domain_idp）
-type DomainIDPRecord struct {
-	DomainID  string    `gorm:"column:domain_id;size:32;primaryKey" json:"domain_id"`
-	IDPType   string    `gorm:"column:idp_type;size:32;primaryKey" json:"idp_type"`
-	CreatedAt time.Time `gorm:"column:created_at;not null" json:"created_at"`
-}
-
-func (DomainIDPRecord) TableName() string { return "t_domain_idp" }
-
 // DomainIDPConfig 域 IDP 配置表（t_domain_idp_config）
-// 域级别的 IDP 默认配置，引用 t_idp_key 中的 t_app_id
+// 域级别的 IDP 配置，同时也是域允许使用的 IDP 列表（有配置即允许）
 type DomainIDPConfig struct {
 	ID        uint      `gorm:"primaryKey;autoIncrement;column:_id" json:"_id"`
 	DomainID  string    `gorm:"column:domain_id;size:32;not null" json:"domain_id"`

--- a/hermes/models/service.go
+++ b/hermes/models/service.go
@@ -34,13 +34,6 @@ func (Service) TableName() string { return "t_service" }
 
 func (s Service) PrimaryKey() uint { return s.ID }
 
-// ServiceWithKey 带密钥的 Service（Main/Keys 不序列化到 API）
-type ServiceWithKey struct {
-	Service
-	Main []byte   `json:"-"` // 当前主密钥（48 字节 seed）
-	Keys [][]byte `json:"-"` // 所有有效密钥（包括主密钥和轮换中的旧密钥）
-}
-
 // GetRequiredIdentities 解析访问该服务需要绑定的身份类型
 func (s *Service) GetRequiredIdentities() []string {
 	if s.RequiredIdentities == nil || *s.RequiredIdentities == "" {

--- a/hermes/provision.go
+++ b/hermes/provision.go
@@ -3,7 +3,6 @@ package hermes
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/go-json-experiment/json"
@@ -20,9 +19,9 @@ import (
 
 // ==================== Domain 相关 ====================
 
-// GetDomain 获取域基础信息（仅 t_domain，不查 t_domain_idp；需时调 GetDomainAllowedIDPs）
+// GetDomain 获取域基础信息（仅 t_domain 元数据）
 func (s *Service) GetDomain(ctx context.Context, domainID string) (*models.Domain, error) {
-	rec, err := s.getDomainRecordOnly(ctx, domainID)
+	rec, err := s.getDomain(ctx, domainID)
 	if err != nil {
 		return nil, err
 	}
@@ -30,19 +29,10 @@ func (s *Service) GetDomain(ctx context.Context, domainID string) (*models.Domai
 		DomainID:    rec.DomainID,
 		Name:        rec.Name,
 		Description: rec.Description,
-		AllowedIDPs: nil,
 	}, nil
 }
 
-// GetDomainAllowedIDPs 获取域允许的 IDP 类型列表（供应用配置 IDP 时按需拉取）
-func (s *Service) GetDomainAllowedIDPs(ctx context.Context, domainID string) ([]string, error) {
-	if _, err := s.getDomainRecordOnly(ctx, domainID); err != nil {
-		return nil, err
-	}
-	return s.getDomainAllowedIDPs(ctx, domainID)
-}
-
-// ListDomains 列出所有域（仅基础信息，不含 allowed_idps）
+// ListDomains 列出所有域（仅基础信息）
 func (s *Service) ListDomains(ctx context.Context) ([]models.Domain, error) {
 	var recs []models.DomainRecord
 	if err := s.db.WithContext(ctx).Find(&recs).Error; err != nil {
@@ -54,7 +44,6 @@ func (s *Service) ListDomains(ctx context.Context) ([]models.Domain, error) {
 			DomainID:    recs[i].DomainID,
 			Name:        recs[i].Name,
 			Description: recs[i].Description,
-			AllowedIDPs: nil,
 		})
 	}
 	return domains, nil
@@ -62,7 +51,7 @@ func (s *Service) ListDomains(ctx context.Context) ([]models.Domain, error) {
 
 // UpdateDomain 更新域（仅 name、description）
 func (s *Service) UpdateDomain(ctx context.Context, domainID string, req *dto.DomainUpdateRequest) (*models.Domain, error) {
-	if _, err := s.getDomainRecordOnly(ctx, domainID); err != nil {
+	if _, err := s.getDomain(ctx, domainID); err != nil {
 		return nil, err
 	}
 	updates := patch.Collect(
@@ -88,9 +77,6 @@ func (s *Service) DeleteDomain(ctx context.Context, domainID string) error {
 		if err := tx.Where("domain_id = ?", domainID).Delete(&models.DomainIDPConfig{}).Error; err != nil {
 			return err
 		}
-		if err := tx.Where("domain_id = ?", domainID).Delete(&models.DomainIDPRecord{}).Error; err != nil {
-			return err
-		}
 		if err := tx.Where("domain_id = ?", domainID).Delete(&models.Service{}).Error; err != nil {
 			return err
 		}
@@ -108,6 +94,12 @@ func (s *Service) DeleteDomain(ctx context.Context, domainID string) error {
 
 // CreateService 创建服务
 func (s *Service) CreateService(ctx context.Context, req *dto.ServiceCreateRequest) (*models.Service, error) {
+	if err := validation.ValidateID("service_id", req.ServiceID); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateID("domain_id", req.DomainID); err != nil {
+		return nil, err
+	}
 	desc := req.Description
 	svc := &models.Service{
 		ServiceID:            req.ServiceID,
@@ -203,9 +195,6 @@ func (s *Service) DeleteService(ctx context.Context, serviceID string) error {
 
 // ==================== Application 相关 ====================
 
-// appIDPattern 应用标识：字母数字、下划线、连字符，1~64 字符
-var appIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
-
 func marshalOptionalStringSlice(s []string) *string {
 	if len(s) == 0 {
 		return nil
@@ -220,11 +209,14 @@ func marshalOptionalStringSlice(s []string) *string {
 
 // CreateApplication 创建应用
 func (s *Service) CreateApplication(ctx context.Context, req *dto.ApplicationCreateRequest) (*models.Application, error) {
+	if err := validation.ValidateID("domain_id", req.DomainID); err != nil {
+		return nil, err
+	}
 	appID := strings.TrimSpace(req.AppID)
 	if appID == "" {
 		appID = helpers.GenerateID(12)
-	} else if !appIDPattern.MatchString(appID) {
-		return nil, fmt.Errorf("应用标识仅允许字母、数字、下划线、连字符，1~64 字符")
+	} else if err := validation.ValidateID("app_id", appID); err != nil {
+		return nil, err
 	}
 
 	if err := validation.ValidateRedirectURIs(req.AllowedRedirectURIs); err != nil {
@@ -406,23 +398,11 @@ func (s *Service) GetDomainIDPConfig(ctx context.Context, domainID, idpType stri
 	return &cfg, nil
 }
 
-// CreateDomainIDPConfig 创建域 IDP 配置（idp_type 必须在域允许列表中）
+// CreateDomainIDPConfig 创建域 IDP 配置（同时表示该 IDP 在此域下可用）
 func (s *Service) CreateDomainIDPConfig(ctx context.Context, domainID string, req *dto.DomainIDPConfigCreateRequest) (*models.DomainIDPConfig, error) {
-	allowed, err := s.getDomainAllowedIDPs(ctx, domainID)
-	if err != nil {
+	if _, err := s.getDomain(ctx, domainID); err != nil {
 		return nil, err
 	}
-	found := false
-	for _, t := range allowed {
-		if t == req.IDPType {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("IDP %s 不在域 %s 的允许列表中", req.IDPType, domainID)
-	}
-
 	cfg := &models.DomainIDPConfig{
 		DomainID: domainID,
 		IDPType:  req.IDPType,
@@ -549,9 +529,78 @@ func (s *Service) GetServiceChallengeSetting(ctx context.Context, serviceID, cha
 	return &cfg, nil
 }
 
+// ListServiceChallengeSettings 获取服务下所有 Challenge 配置
+func (s *Service) ListServiceChallengeSettings(ctx context.Context, serviceID string) ([]models.ServiceChallengeSetting, error) {
+	var settings []models.ServiceChallengeSetting
+	if err := s.db.WithContext(ctx).Where("service_id = ?", serviceID).Find(&settings).Error; err != nil {
+		return nil, fmt.Errorf("获取 Challenge 配置列表失败: %w", err)
+	}
+	return settings, nil
+}
+
+// CreateServiceChallengeSetting 创建服务 Challenge 配置
+func (s *Service) CreateServiceChallengeSetting(ctx context.Context, serviceID string, req *dto.ServiceChallengeSettingCreateRequest) (*models.ServiceChallengeSetting, error) {
+	if _, err := s.GetService(ctx, serviceID); err != nil {
+		return nil, err
+	}
+	setting := &models.ServiceChallengeSetting{
+		ServiceID: serviceID,
+		Type:      req.Type,
+		ExpiresIn: req.ExpiresIn,
+		Limits:    req.Limits,
+	}
+	if setting.ExpiresIn == 0 {
+		setting.ExpiresIn = 300
+	}
+	if err := s.db.WithContext(ctx).Create(setting).Error; err != nil {
+		return nil, fmt.Errorf("创建 Challenge 配置失败: %w", err)
+	}
+	return setting, nil
+}
+
+// UpdateServiceChallengeSetting 更新服务 Challenge 配置（JSON Merge Patch 语义）
+func (s *Service) UpdateServiceChallengeSetting(ctx context.Context, serviceID, challengeType string, req *dto.ServiceChallengeSettingUpdateRequest) error {
+	updates := patch.Collect(
+		patch.Field("expires_in", req.ExpiresIn),
+	)
+	if req.Limits.IsPresent() {
+		if req.Limits.IsNull() {
+			updates["limits"] = nil
+		} else {
+			updates["limits"] = req.Limits.Value()
+		}
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	result := s.db.WithContext(ctx).Model(&models.ServiceChallengeSetting{}).
+		Where("service_id = ? AND `type` = ?", serviceID, challengeType).Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("更新 Challenge 配置失败: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("challenge 配置不存在: service_id=%s, type=%s", serviceID, challengeType)
+	}
+	return nil
+}
+
+// DeleteServiceChallengeSetting 删除服务 Challenge 配置
+func (s *Service) DeleteServiceChallengeSetting(ctx context.Context, serviceID, challengeType string) error {
+	result := s.db.WithContext(ctx).
+		Where("service_id = ? AND `type` = ?", serviceID, challengeType).
+		Delete(&models.ServiceChallengeSetting{})
+	if result.Error != nil {
+		return fmt.Errorf("删除 Challenge 配置失败: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("challenge 配置不存在: service_id=%s, type=%s", serviceID, challengeType)
+	}
+	return nil
+}
+
 // ==================== 内部辅助方法 ====================
 
-func (s *Service) getDomainRecordOnly(ctx context.Context, domainID string) (*models.DomainRecord, error) {
+func (s *Service) getDomain(ctx context.Context, domainID string) (*models.DomainRecord, error) {
 	var rec models.DomainRecord
 	if err := s.db.WithContext(ctx).Where("domain_id = ?", domainID).First(&rec).Error; err != nil {
 		return nil, fmt.Errorf("域 %s 不存在: %w", domainID, err)
@@ -559,48 +608,19 @@ func (s *Service) getDomainRecordOnly(ctx context.Context, domainID string) (*mo
 	return &rec, nil
 }
 
-func (s *Service) getDomainFromDB(ctx context.Context, domainID string) (*models.Domain, error) {
-	rec, err := s.getDomainRecordOnly(ctx, domainID)
-	if err != nil {
-		return nil, err
-	}
-	allowedIDPs, err := s.getDomainAllowedIDPs(ctx, domainID)
-	if err != nil {
-		return nil, err
-	}
-	return &models.Domain{
-		DomainID:    rec.DomainID,
-		Name:        rec.Name,
-		Description: rec.Description,
-		AllowedIDPs: allowedIDPs,
-	}, nil
-}
-
-func (s *Service) getDomainAllowedIDPs(ctx context.Context, domainID string) ([]string, error) {
-	var rows []models.DomainIDPRecord
-	if err := s.db.WithContext(ctx).Where("domain_id = ?", domainID).Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("查询域 IDP 列表失败: %w", err)
-	}
-	out := make([]string, 0, len(rows))
-	for i := range rows {
-		out = append(out, rows[i].IDPType)
-	}
-	return out, nil
-}
-
 func (s *Service) ensureIDPAllowedForApplication(ctx context.Context, appID, idpType string) error {
 	app, err := s.GetApplication(ctx, appID)
 	if err != nil {
 		return err
 	}
-	allowed, err := s.getDomainAllowedIDPs(ctx, app.DomainID)
+	configs, err := s.GetDomainIDPConfigs(ctx, app.DomainID)
 	if err != nil {
 		return err
 	}
-	for _, t := range allowed {
-		if t == idpType {
+	for _, cfg := range configs {
+		if cfg.IDPType == idpType {
 			return nil
 		}
 	}
-	return fmt.Errorf("IDP %s 不在域 %s 的允许列表中", idpType, app.DomainID)
+	return fmt.Errorf("IDP %s 未在域 %s 中配置", idpType, app.DomainID)
 }

--- a/hermes/user.go
+++ b/hermes/user.go
@@ -300,16 +300,6 @@ func (s *Service) GetUserCredentialsByType(ctx context.Context, openid, credType
 	return credentials, nil
 }
 
-// GetEnabledUserCredentialsByType 获取用户已启用的指定类型的凭证（TOTP 类型自动解密 Secret）
-func (s *Service) GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
-	var credentials []models.UserCredential
-	if err := s.db.WithContext(ctx).Where("openid = ? AND type = ? AND enabled = ?", openid, credType, true).Find(&credentials).Error; err != nil {
-		return nil, err
-	}
-	s.decryptCredentialSecrets(credentials)
-	return credentials, nil
-}
-
 // UpdateCredential 更新凭证
 func (s *Service) UpdateCredential(ctx context.Context, credentialID string, updates map[string]any) error {
 	return s.db.WithContext(ctx).Model(&models.UserCredential{}).Where("credential_id = ?", credentialID).Updates(updates).Error
@@ -321,16 +311,6 @@ func (s *Service) UpdateCredentialSignCount(ctx context.Context, credentialID st
 		"secret":       gorm.Expr("JSON_SET(secret, '$.sign_count', ?)", signCount),
 		"last_used_at": time.Now(),
 	})
-}
-
-// EnableCredential 启用凭证
-func (s *Service) EnableCredential(ctx context.Context, credentialID string) error {
-	return s.UpdateCredential(ctx, credentialID, map[string]any{"enabled": true})
-}
-
-// DisableCredential 禁用凭证
-func (s *Service) DisableCredential(ctx context.Context, credentialID string) error {
-	return s.UpdateCredential(ctx, credentialID, map[string]any{"enabled": false})
 }
 
 // DeleteCredential 删除凭证

--- a/hermes/user.go
+++ b/hermes/user.go
@@ -258,44 +258,55 @@ func (s *Service) UpdatePassword(ctx context.Context, openid, oldPassword, newPa
 
 // ==================== WebAuthn 凭证管理 ====================
 
-// CreateCredential 创建凭证
+// CreateCredential 创建凭证（TOTP 类型自动加密 Secret）
 func (s *Service) CreateCredential(ctx context.Context, cred *models.UserCredential) error {
+	if models.CredentialType(cred.Type) == models.CredentialTypeTOTP && cred.Secret != "" {
+		encrypted, err := s.encryptSecret(cred.Secret, cred.OpenID)
+		if err != nil {
+			return fmt.Errorf("加密凭证失败: %w", err)
+		}
+		cred.Secret = encrypted
+	}
 	return s.db.WithContext(ctx).Create(cred).Error
 }
 
-// GetCredentialByID 根据凭证 ID 获取凭证
+// GetCredentialByID 根据凭证 ID 获取凭证（TOTP 类型自动解密 Secret）
 func (s *Service) GetCredentialByID(ctx context.Context, credentialID string) (*models.UserCredential, error) {
 	var cred models.UserCredential
 	if err := s.db.WithContext(ctx).Where("credential_id = ?", credentialID).First(&cred).Error; err != nil {
 		return nil, err
 	}
+	s.decryptCredentialSecret(&cred)
 	return &cred, nil
 }
 
-// GetUserCredentials 获取用户所有凭证
+// GetUserCredentials 获取用户所有凭证（TOTP 类型自动解密 Secret）
 func (s *Service) GetUserCredentials(ctx context.Context, openid string) ([]models.UserCredential, error) {
 	var credentials []models.UserCredential
 	if err := s.db.WithContext(ctx).Where("openid = ?", openid).Find(&credentials).Error; err != nil {
 		return nil, err
 	}
+	s.decryptCredentialSecrets(credentials)
 	return credentials, nil
 }
 
-// GetUserCredentialsByType 获取用户指定类型的凭证
+// GetUserCredentialsByType 获取用户指定类型的凭证（TOTP 类型自动解密 Secret）
 func (s *Service) GetUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
 	var credentials []models.UserCredential
 	if err := s.db.WithContext(ctx).Where("openid = ? AND type = ?", openid, credType).Find(&credentials).Error; err != nil {
 		return nil, err
 	}
+	s.decryptCredentialSecrets(credentials)
 	return credentials, nil
 }
 
-// GetEnabledUserCredentialsByType 获取用户已启用的指定类型的凭证
+// GetEnabledUserCredentialsByType 获取用户已启用的指定类型的凭证（TOTP 类型自动解密 Secret）
 func (s *Service) GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
 	var credentials []models.UserCredential
 	if err := s.db.WithContext(ctx).Where("openid = ? AND type = ? AND enabled = ?", openid, credType, true).Find(&credentials).Error; err != nil {
 		return nil, err
 	}
+	s.decryptCredentialSecrets(credentials)
 	return credentials, nil
 }
 
@@ -336,12 +347,13 @@ func (s *Service) GetOpenIDByCredentialID(ctx context.Context, credentialID stri
 	return cred.OpenID, nil
 }
 
-// GetCredentialByInternalID 根据内部主键 ID 获取凭证
+// GetCredentialByInternalID 根据内部主键 ID 获取凭证（TOTP 类型自动解密 Secret）
 func (s *Service) GetCredentialByInternalID(ctx context.Context, id uint) (*models.UserCredential, error) {
 	var cred models.UserCredential
 	if err := s.db.WithContext(ctx).Where("_id = ?", id).First(&cred).Error; err != nil {
 		return nil, err
 	}
+	s.decryptCredentialSecret(&cred)
 	return &cred, nil
 }
 
@@ -599,4 +611,43 @@ func isPhone(s string) bool {
 
 func hashPhone(phone string) string {
 	return cryptoutil.Hash(phone)
+}
+
+// ==================== 凭证加解密辅助 ====================
+
+// encryptSecret 加密凭证密钥（AES-256-GCM，openid 作为 AAD）
+func (s *Service) encryptSecret(plaintext, openid string) (string, error) {
+	key, err := config.GetDBEncKeyRaw()
+	if err != nil {
+		return "", fmt.Errorf("获取加密密钥失败: %w", err)
+	}
+	return cryptoutil.Encrypt(key, plaintext, openid)
+}
+
+// decryptSecret 解密凭证密钥
+func (s *Service) decryptSecret(ciphertext, openid string) (string, error) {
+	key, err := config.GetDBEncKeyRaw()
+	if err != nil {
+		return "", fmt.Errorf("获取加密密钥失败: %w", err)
+	}
+	return cryptoutil.Decrypt(key, ciphertext, openid)
+}
+
+// decryptCredentialSecret 解密单个凭证的 Secret（仅 TOTP 类型）
+func (s *Service) decryptCredentialSecret(cred *models.UserCredential) {
+	if models.CredentialType(cred.Type) == models.CredentialTypeTOTP && cred.Secret != "" {
+		plain, err := s.decryptSecret(cred.Secret, cred.OpenID)
+		if err != nil {
+			logger.Warnf("[UserService] 解密 TOTP 密钥失败 (ID=%d): %v", cred.ID, err)
+			return
+		}
+		cred.Secret = plain
+	}
+}
+
+// decryptCredentialSecrets 批量解密凭证的 Secret（仅 TOTP 类型）
+func (s *Service) decryptCredentialSecrets(creds []models.UserCredential) {
+	for i := range creds {
+		s.decryptCredentialSecret(&creds[i])
+	}
 }

--- a/hermes/validation/id.go
+++ b/hermes/validation/id.go
@@ -1,0 +1,16 @@
+package validation
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var idPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{4,32}$`)
+
+// ValidateID 校验资源标识（域/应用/服务 ID）：字母、数字、下划线、连字符，4~32 字符
+func ValidateID(kind, id string) error {
+	if !idPattern.MatchString(id) {
+		return fmt.Errorf("%s 仅允许字母、数字、下划线、连字符，4~32 字符", kind)
+	}
+	return nil
+}

--- a/iris/config/config.go
+++ b/iris/config/config.go
@@ -41,3 +41,5 @@ func GetAegisSecretKeyBytes() ([]byte, error) {
 	}
 	return secretBytes, nil
 }
+
+// (GetDBEncKeyRaw removed — encryption moved to hermes layer)

--- a/iris/credential.go
+++ b/iris/credential.go
@@ -21,12 +21,9 @@ type CredentialStore interface {
 	CreateCredential(ctx context.Context, cred *models.UserCredential) error
 	GetUserCredentials(ctx context.Context, openid string) ([]models.UserCredential, error)
 	GetUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error)
-	GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error)
 	GetCredentialByID(ctx context.Context, credentialID string) (*models.UserCredential, error)
 	UpdateCredential(ctx context.Context, credentialID string, updates map[string]any) error
 	UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error
-	EnableCredential(ctx context.Context, credentialID string) error
-	DisableCredential(ctx context.Context, credentialID string) error
 	DeleteCredential(ctx context.Context, openid, credentialID string) error
 	DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error
 }
@@ -44,14 +41,46 @@ func NewCredentialService(store CredentialStore) *CredentialService {
 
 // ==================== TOTP ====================
 
-// SetupTOTP 初始化 TOTP（生成密钥，但尚未启用）
+// isActiveTOTPCredential TOTP 已绑定可用：已写 last_used_at，或兼容仅 enabled 的旧数据
+func isActiveTOTPCredential(c *models.UserCredential) bool {
+	if c.Type != string(models.CredentialTypeTOTP) {
+		return false
+	}
+	if c.LastUsedAt != nil {
+		return true
+	}
+	return c.Enabled
+}
+
+func isPendingTOTPCredential(c *models.UserCredential) bool {
+	return c.Type == string(models.CredentialTypeTOTP) && !isActiveTOTPCredential(c)
+}
+
+// credentialActiveInMFA MFA 展示与摘要：TOTP 按激活判定；WebAuthn 等以行存在且 enabled（遗留软禁用）
+func credentialActiveInMFA(c *models.UserCredential) bool {
+	switch models.CredentialType(c.Type) {
+	case models.CredentialTypeTOTP:
+		return isActiveTOTPCredential(c)
+	default:
+		return c.Enabled
+	}
+}
+
+// SetupTOTP 初始化 TOTP（明文 Secret 交给 store，Hermes 层负责加密）
 func (s *CredentialService) SetupTOTP(ctx context.Context, req *models.TOTPSetupRequest) (*models.TOTPSetupResponse, error) {
-	creds, err := s.store.GetEnabledUserCredentialsByType(ctx, req.OpenID, string(models.CredentialTypeTOTP))
+	creds, err := s.store.GetUserCredentialsByType(ctx, req.OpenID, string(models.CredentialTypeTOTP))
 	if err != nil {
 		return nil, fmt.Errorf("查询 TOTP 失败: %w", err)
 	}
+	for i := range creds {
+		if isActiveTOTPCredential(&creds[i]) {
+			return nil, errors.New("用户已绑定 TOTP")
+		}
+	}
 	if len(creds) > 0 {
-		return nil, errors.New("用户已绑定 TOTP")
+		if err := s.store.DeleteCredentialByOpenIDAndType(ctx, req.OpenID, string(models.CredentialTypeTOTP)); err != nil {
+			return nil, fmt.Errorf("清理未完成的 TOTP 失败: %w", err)
+		}
 	}
 
 	secretBytes := make([]byte, 20)
@@ -68,7 +97,6 @@ func (s *CredentialService) SetupTOTP(ctx context.Context, req *models.TOTPSetup
 	otpauthURI := fmt.Sprintf("otpauth://totp/%s:%s?secret=%s&issuer=%s&algorithm=SHA1&digits=6&period=30",
 		url.PathEscape(issuer), url.PathEscape(req.OpenID), secret, url.QueryEscape(issuer))
 
-	// 明文传给 store，hermes 层负责加密
 	credential := &models.UserCredential{
 		OpenID:  req.OpenID,
 		Type:    string(models.CredentialTypeTOTP),
@@ -87,9 +115,8 @@ func (s *CredentialService) SetupTOTP(ctx context.Context, req *models.TOTPSetup
 	}, nil
 }
 
-// ConfirmTOTP 确认 TOTP 绑定（验证一次后启用）
+// ConfirmTOTP 确认 TOTP 绑定（验证一次后写入 last_used_at）
 func (s *CredentialService) ConfirmTOTP(ctx context.Context, req *models.ConfirmTOTPRequest) error {
-	// 查找用户未启用的 TOTP 凭证
 	creds, err := s.store.GetUserCredentialsByType(ctx, req.OpenID, string(models.CredentialTypeTOTP))
 	if err != nil {
 		return fmt.Errorf("查询凭证失败: %w", err)
@@ -97,33 +124,32 @@ func (s *CredentialService) ConfirmTOTP(ctx context.Context, req *models.Confirm
 
 	var credential *models.UserCredential
 	for i := range creds {
-		if creds[i].ID == req.CredentialID && !creds[i].Enabled {
+		if creds[i].ID == req.CredentialID && isPendingTOTPCredential(&creds[i]) {
 			credential = &creds[i]
 			break
 		}
 	}
 	if credential == nil {
-		return errors.New("凭证不存在或已启用")
+		return errors.New("凭证不存在或已激活")
 	}
 
-	// hermes 层已解密，直接使用
+	// Hermes 层已解密 TOTP Secret
 	if !totp.Validate(req.Code, credential.Secret) {
 		return errors.New("验证码错误")
 	}
 
 	now := time.Now()
 	updates := map[string]any{
-		"enabled":      true,
 		"last_used_at": now,
+		"enabled":      true,
 	}
-	// TOTP 凭证没有 credential_id，通过内部主键 ID 更新
 	if credential.CredentialID != nil {
 		if err := s.store.UpdateCredential(ctx, *credential.CredentialID, updates); err != nil {
-			return fmt.Errorf("启用凭证失败: %w", err)
+			return fmt.Errorf("确认 TOTP 失败: %w", err)
 		}
 	} else {
 		if err := s.store.UpdateCredentialByInternalID(ctx, credential.ID, updates); err != nil {
-			return fmt.Errorf("启用凭证失败: %w", err)
+			return fmt.Errorf("确认 TOTP 失败: %w", err)
 		}
 	}
 
@@ -133,23 +159,28 @@ func (s *CredentialService) ConfirmTOTP(ctx context.Context, req *models.Confirm
 
 // VerifyTOTP 验证 TOTP
 func (s *CredentialService) VerifyTOTP(ctx context.Context, req *models.VerifyTOTPRequest) error {
-	creds, err := s.store.GetEnabledUserCredentialsByType(ctx, req.OpenID, string(models.CredentialTypeTOTP))
+	creds, err := s.store.GetUserCredentialsByType(ctx, req.OpenID, string(models.CredentialTypeTOTP))
 	if err != nil {
 		return fmt.Errorf("查询凭证失败: %w", err)
 	}
-	if len(creds) == 0 {
+	var active []models.UserCredential
+	for i := range creds {
+		if isActiveTOTPCredential(&creds[i]) {
+			active = append(active, creds[i])
+		}
+	}
+	if len(active) == 0 {
 		return errors.New("用户未绑定 TOTP")
 	}
 
-	// hermes 层已解密，直接使用
-	if !totp.Validate(req.Code, creds[0].Secret) {
+	if !totp.Validate(req.Code, active[0].Secret) {
 		return errors.New("验证码错误")
 	}
 
 	return nil
 }
 
-// DisableTOTP 禁用 TOTP（删除所有 TOTP 凭证）
+// DisableTOTP 禁用 TOTP（按类型删除全部凭证行）
 func (s *CredentialService) DisableTOTP(ctx context.Context, openid string) error {
 	if err := s.store.DeleteCredentialByOpenIDAndType(ctx, openid, string(models.CredentialTypeTOTP)); err != nil {
 		return fmt.Errorf("删除 TOTP 凭证失败: %w", err)
@@ -158,37 +189,32 @@ func (s *CredentialService) DisableTOTP(ctx context.Context, openid string) erro
 	return nil
 }
 
-// SetTOTPEnabled 设置 TOTP 启用状态
+// SetTOTPEnabled 关闭 TOTP 即删除凭证；开启请走 Setup/Confirm 流程
 func (s *CredentialService) SetTOTPEnabled(ctx context.Context, openid string, enabled bool) error {
-	creds, err := s.store.GetUserCredentialsByType(ctx, openid, string(models.CredentialTypeTOTP))
-	if err != nil {
-		return fmt.Errorf("查询凭证失败: %w", err)
+	if enabled {
+		return errors.New("启用 TOTP 请使用扫码绑定流程")
 	}
-	if len(creds) == 0 {
-		return errors.New("用户未绑定 TOTP")
-	}
-	updates := map[string]any{"enabled": enabled}
-	if creds[0].CredentialID != nil {
-		return s.store.UpdateCredential(ctx, *creds[0].CredentialID, updates)
-	}
-	return s.store.UpdateCredentialByInternalID(ctx, creds[0].ID, updates)
+	return s.DisableTOTP(ctx, openid)
 }
 
 // ==================== WebAuthn ====================
 
-// SetWebAuthnEnabled 设置 WebAuthn 启用状态
+// SetWebAuthnEnabled 关闭即删除凭证；已存在则视为已启用
 func (s *CredentialService) SetWebAuthnEnabled(ctx context.Context, openid, credentialID string, enabled bool) error {
-	cred, err := s.store.GetCredentialByID(ctx, credentialID)
-	if err != nil {
-		return errors.New("凭证不存在")
-	}
-	if cred.OpenID != openid {
-		return errors.New("凭证不存在")
-	}
 	if enabled {
-		return s.store.EnableCredential(ctx, credentialID)
+		cred, err := s.store.GetCredentialByID(ctx, credentialID)
+		if err != nil {
+			return errors.New("凭证不存在")
+		}
+		if cred.OpenID != openid {
+			return errors.New("凭证不存在")
+		}
+		return nil
 	}
-	return s.store.DisableCredential(ctx, credentialID)
+	if err := s.store.DeleteCredential(ctx, openid, credentialID); err != nil {
+		return fmt.Errorf("删除凭证失败: %w", err)
+	}
+	return nil
 }
 
 // DeleteWebAuthn 删除 WebAuthn 凭证
@@ -211,7 +237,7 @@ func (s *CredentialService) GetUserMFAStatus(ctx context.Context, openid string)
 
 	status := &models.MFAStatus{}
 	for _, cred := range credentials {
-		if !cred.Enabled {
+		if !credentialActiveInMFA(&cred) {
 			continue
 		}
 		switch models.CredentialType(cred.Type) {
@@ -235,13 +261,13 @@ func (s *CredentialService) GetUserCredentialSummaries(ctx context.Context, open
 
 	summaries := make([]models.CredentialSummary, 0, len(credentials))
 	for _, cred := range credentials {
-		if !cred.Enabled {
+		if !credentialActiveInMFA(&cred) {
 			continue
 		}
 		summary := models.CredentialSummary{
 			ID:         cred.ID,
 			Type:       cred.Type,
-			Enabled:    cred.Enabled,
+			Enabled:    credentialActiveInMFA(&cred),
 			LastUsedAt: cred.LastUsedAt,
 			CreatedAt:  cred.CreatedAt,
 		}
@@ -257,7 +283,3 @@ func (s *CredentialService) GetUserCredentialSummaries(ctx context.Context, open
 	}
 	return summaries, nil
 }
-
-// ==================== 内部辅助 ====================
-
-// (empty — encryption moved to hermes layer)

--- a/iris/credential.go
+++ b/iris/credential.go
@@ -9,12 +9,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-json-experiment/json"
 	"github.com/pquerna/otp/totp"
 
 	"github.com/heliannuuthus/helios/aegis/models"
-	"github.com/heliannuuthus/helios/hermes/config"
-	cryptoutil "github.com/heliannuuthus/helios/pkg/crypto"
 	"github.com/heliannuuthus/helios/pkg/logger"
 )
 
@@ -27,9 +24,11 @@ type CredentialStore interface {
 	GetEnabledUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error)
 	GetCredentialByID(ctx context.Context, credentialID string) (*models.UserCredential, error)
 	UpdateCredential(ctx context.Context, credentialID string, updates map[string]any) error
+	UpdateCredentialByInternalID(ctx context.Context, id uint, updates map[string]any) error
 	EnableCredential(ctx context.Context, credentialID string) error
 	DisableCredential(ctx context.Context, credentialID string) error
 	DeleteCredential(ctx context.Context, openid, credentialID string) error
+	DeleteCredentialByOpenIDAndType(ctx context.Context, openid, credType string) error
 }
 
 // CredentialService 凭证业务服务（TOTP/WebAuthn 业务逻辑）
@@ -69,16 +68,12 @@ func (s *CredentialService) SetupTOTP(ctx context.Context, req *models.TOTPSetup
 	otpauthURI := fmt.Sprintf("otpauth://totp/%s:%s?secret=%s&issuer=%s&algorithm=SHA1&digits=6&period=30",
 		url.PathEscape(issuer), url.PathEscape(req.OpenID), secret, url.QueryEscape(issuer))
 
-	encryptedSecret, err := encryptTOTPSecret(secret, req.OpenID)
-	if err != nil {
-		return nil, err
-	}
-
+	// 明文传给 store，hermes 层负责加密
 	credential := &models.UserCredential{
 		OpenID:  req.OpenID,
 		Type:    string(models.CredentialTypeTOTP),
 		Enabled: false,
-		Secret:  encryptedSecret,
+		Secret:  secret,
 	}
 
 	if err := s.store.CreateCredential(ctx, credential); err != nil {
@@ -111,28 +106,23 @@ func (s *CredentialService) ConfirmTOTP(ctx context.Context, req *models.Confirm
 		return errors.New("凭证不存在或已启用")
 	}
 
-	secret, err := decryptTOTPSecret(credential.Secret, req.OpenID)
-	if err != nil {
-		return err
-	}
-
-	if !totp.Validate(req.Code, secret) {
+	// hermes 层已解密，直接使用
+	if !totp.Validate(req.Code, credential.Secret) {
 		return errors.New("验证码错误")
 	}
 
 	now := time.Now()
-	// 通过 credential_id 或 openid+type 更新
+	updates := map[string]any{
+		"enabled":      true,
+		"last_used_at": now,
+	}
+	// TOTP 凭证没有 credential_id，通过内部主键 ID 更新
 	if credential.CredentialID != nil {
-		if err := s.store.UpdateCredential(ctx, *credential.CredentialID, map[string]any{
-			"enabled":      true,
-			"last_used_at": now,
-		}); err != nil {
+		if err := s.store.UpdateCredential(ctx, *credential.CredentialID, updates); err != nil {
 			return fmt.Errorf("启用凭证失败: %w", err)
 		}
 	} else {
-		// TOTP 没有 credential_id，直接启用
-		if err := s.store.EnableCredential(ctx, fmt.Sprintf("_internal_%d", credential.ID)); err != nil {
-			// fallback: 尝试通过类型查找并启用
+		if err := s.store.UpdateCredentialByInternalID(ctx, credential.ID, updates); err != nil {
 			return fmt.Errorf("启用凭证失败: %w", err)
 		}
 	}
@@ -151,12 +141,8 @@ func (s *CredentialService) VerifyTOTP(ctx context.Context, req *models.VerifyTO
 		return errors.New("用户未绑定 TOTP")
 	}
 
-	secret, err := decryptTOTPSecret(creds[0].Secret, req.OpenID)
-	if err != nil {
-		return err
-	}
-
-	if !totp.Validate(req.Code, secret) {
+	// hermes 层已解密，直接使用
+	if !totp.Validate(req.Code, creds[0].Secret) {
 		return errors.New("验证码错误")
 	}
 
@@ -165,16 +151,8 @@ func (s *CredentialService) VerifyTOTP(ctx context.Context, req *models.VerifyTO
 
 // DisableTOTP 禁用 TOTP（删除所有 TOTP 凭证）
 func (s *CredentialService) DisableTOTP(ctx context.Context, openid string) error {
-	creds, err := s.store.GetUserCredentialsByType(ctx, openid, string(models.CredentialTypeTOTP))
-	if err != nil {
-		return fmt.Errorf("查询凭证失败: %w", err)
-	}
-	for _, cred := range creds {
-		if cred.CredentialID != nil {
-			if err := s.store.DeleteCredential(ctx, openid, *cred.CredentialID); err != nil {
-				logger.Warnf("[Credential] 删除 TOTP 凭证失败 - OpenID: %s, Error: %v", openid, err)
-			}
-		}
+	if err := s.store.DeleteCredentialByOpenIDAndType(ctx, openid, string(models.CredentialTypeTOTP)); err != nil {
+		return fmt.Errorf("删除 TOTP 凭证失败: %w", err)
 	}
 	logger.Infof("[Credential] TOTP 已禁用 - OpenID: %s", openid)
 	return nil
@@ -189,13 +167,11 @@ func (s *CredentialService) SetTOTPEnabled(ctx context.Context, openid string, e
 	if len(creds) == 0 {
 		return errors.New("用户未绑定 TOTP")
 	}
+	updates := map[string]any{"enabled": enabled}
 	if creds[0].CredentialID != nil {
-		if enabled {
-			return s.store.EnableCredential(ctx, *creds[0].CredentialID)
-		}
-		return s.store.DisableCredential(ctx, *creds[0].CredentialID)
+		return s.store.UpdateCredential(ctx, *creds[0].CredentialID, updates)
 	}
-	return nil
+	return s.store.UpdateCredentialByInternalID(ctx, creds[0].ID, updates)
 }
 
 // ==================== WebAuthn ====================
@@ -284,39 +260,4 @@ func (s *CredentialService) GetUserCredentialSummaries(ctx context.Context, open
 
 // ==================== 内部辅助 ====================
 
-func encryptTOTPSecret(secret, openid string) (string, error) {
-	secretData := &models.TOTPSecret{Secret: secret}
-	secretJSON, err := json.Marshal(secretData)
-	if err != nil {
-		return "", fmt.Errorf("序列化密钥失败: %w", err)
-	}
-
-	encKey, err := config.GetDBEncKeyRaw()
-	if err != nil {
-		return "", fmt.Errorf("获取加密密钥失败: %w", err)
-	}
-
-	encrypted, err := cryptoutil.Encrypt(encKey, string(secretJSON), openid)
-	if err != nil {
-		return "", fmt.Errorf("加密密钥失败: %w", err)
-	}
-	return encrypted, nil
-}
-
-func decryptTOTPSecret(encryptedSecret, openid string) (string, error) {
-	encKey, err := config.GetDBEncKeyRaw()
-	if err != nil {
-		return "", fmt.Errorf("获取加密密钥失败: %w", err)
-	}
-
-	secretJSON, err := cryptoutil.Decrypt(encKey, encryptedSecret, openid)
-	if err != nil {
-		return "", fmt.Errorf("解密密钥失败: %w", err)
-	}
-
-	var secretData models.TOTPSecret
-	if err := json.Unmarshal([]byte(secretJSON), &secretData); err != nil {
-		return "", fmt.Errorf("解析密钥失败: %w", err)
-	}
-	return secretData.Secret, nil
-}
+// (empty — encryption moved to hermes layer)

--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func main() {
 			domains.GET("", app.HermesHandler.ListDomains)
 			domains.GET("/:domain_id", app.HermesHandler.GetDomain)
 			domains.PATCH("/:domain_id", adminRelation, app.HermesHandler.UpdateDomain)
-			domains.GET("/:domain_id/idps", app.HermesHandler.GetDomainAllowedIDPs)
+			// 域 IDP 配置列表统一走 /idp-configs 端点
 
 			// 域 IDP 配置：domains/:domain_id/idp-configs
 			idpConfigs := domains.Group("/:domain_id/idp-configs")

--- a/proto/hermes/v1/user.proto
+++ b/proto/hermes/v1/user.proto
@@ -50,6 +50,8 @@ service UserService {
   rpc EnableCredential(CredentialIDRequest) returns (google.protobuf.Empty);
   rpc DisableCredential(CredentialIDRequest) returns (google.protobuf.Empty);
   rpc DeleteCredential(DeleteCredentialRequest) returns (google.protobuf.Empty);
+  rpc DeleteCredentialByOpenIDAndType(DeleteCredentialByTypeRequest) returns (google.protobuf.Empty);
+  rpc UpdateCredentialByInternalID(UpdateCredentialByInternalIDRequest) returns (google.protobuf.Empty);
   rpc GetOpenIDByCredentialID(CredentialIDRequest) returns (OpenIDResponse);
 
 
@@ -224,6 +226,18 @@ message UpdateCredentialSignCountRequest {
 message DeleteCredentialRequest {
   string openid = 1;
   string credential_id = 2;
+}
+
+message DeleteCredentialByTypeRequest {
+  string openid = 1;
+  string type = 2;
+}
+
+message UpdateCredentialByInternalIDRequest {
+  uint32 id = 1;
+  optional bool enabled = 2;
+  optional string secret = 3;
+  optional google.protobuf.Timestamp last_used_at = 4;
 }
 
 message OpenIDResponse {

--- a/proto/hermes/v1/user.proto
+++ b/proto/hermes/v1/user.proto
@@ -44,11 +44,8 @@ service UserService {
   rpc GetCredentialByID(CredentialIDRequest) returns (UserCredential);
   rpc GetUserCredentials(OpenIDRequest) returns (UserCredentialList);
   rpc GetUserCredentialsByType(GetCredentialsByTypeRequest) returns (UserCredentialList);
-  rpc GetEnabledUserCredentialsByType(GetCredentialsByTypeRequest) returns (UserCredentialList);
   rpc UpdateCredential(UpdateCredentialRequest) returns (google.protobuf.Empty);
   rpc UpdateCredentialSignCount(UpdateCredentialSignCountRequest) returns (google.protobuf.Empty);
-  rpc EnableCredential(CredentialIDRequest) returns (google.protobuf.Empty);
-  rpc DisableCredential(CredentialIDRequest) returns (google.protobuf.Empty);
   rpc DeleteCredential(DeleteCredentialRequest) returns (google.protobuf.Empty);
   rpc DeleteCredentialByOpenIDAndType(DeleteCredentialByTypeRequest) returns (google.protobuf.Empty);
   rpc UpdateCredentialByInternalID(UpdateCredentialByInternalIDRequest) returns (google.protobuf.Empty);
@@ -202,8 +199,7 @@ message CreateCredentialRequest {
   string openid = 1;
   optional string credential_id = 2;
   string type = 3;
-  bool enabled = 4;
-  string secret = 5;
+  string secret = 4;
 }
 
 message GetCredentialsByTypeRequest {
@@ -213,9 +209,8 @@ message GetCredentialsByTypeRequest {
 
 message UpdateCredentialRequest {
   string credential_id = 1;
-  optional bool enabled = 2;
-  optional string secret = 3;
-  optional google.protobuf.Timestamp last_used_at = 4;
+  optional string secret = 2;
+  optional google.protobuf.Timestamp last_used_at = 3;
 }
 
 message UpdateCredentialSignCountRequest {

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -16,7 +16,9 @@ import (
 	"github.com/heliannuuthus/helios/iris"
 	"github.com/heliannuuthus/helios/zwei"
 	"github.com/heliannuuthus/helios/zwei/config"
+)
 
+import (
 	_ "github.com/heliannuuthus/helios/docs"
 )
 

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -16,9 +16,7 @@ import (
 	"github.com/heliannuuthus/helios/iris"
 	"github.com/heliannuuthus/helios/zwei"
 	"github.com/heliannuuthus/helios/zwei/config"
-)
 
-import (
 	_ "github.com/heliannuuthus/helios/docs"
 )
 


### PR DESCRIPTION
## Summary

- **补齐管理端 HTTP API**：新增 ServiceChallengeSetting 完整 CRUD（DTO/service/handler/routes）；补齐 DeleteDomain、DeleteApplication、DeleteGroup handler 并统一 204 返回；注册 DomainIDPConfig 和 IDP Keys 路由到 `cmd/hermes/main.go`
- **统一 DomainIDPConfig 为单一数据源**：移除 `AllowedIDPs []string`、`DomainIDPRecord` 模型及 `getDomainAllowedIDPs` 方法链路，`t_domain_idp_config` 成为域 IDP 配置的唯一数据源（有配置即允许）；aegis 全链路适配 `GetDomainIDPConfigs`（contract → adapter → rpc → cache → handler）
- **清理 hermes 层聚合类型**：移除 `DomainWithKey`/`ServiceWithKey`/`ApplicationWithKey` 模型及 `GetXxxWithKey` 方法，数据聚合由 aegis cache 层按需组装
- **ID 校验规范化**：新增 `validation.ValidateID`，统一 app_id/service_id/domain_id 为 4-32 字符（字母、数字、下划线、连字符）
- **文档清理**：移除 CLAUDE.md 中 `hermes/upload/` 引用（功能已迁移至 chaos）

## Test plan

- [ ] `make generate` 通过 ✅
- [ ] `make lint` 0 issues ✅
- [ ] 验证 DomainIDPConfig CRUD 端点正常工作
- [ ] 验证 ServiceChallengeSetting CRUD 端点正常工作
- [ ] 验证 DeleteDomain/DeleteApplication/DeleteGroup 返回 204
- [ ] 验证 ID 长度 < 4 或 > 32 时创建应用/服务被拒绝
- [ ] 验证 aegis 认证流程中 IDP 允许检查走 DomainIDPConfigs 缓存