### PR TITLE
fix(aegis): route passkey through idp entry

### DIFF
--- a/aegis/auth/dto.go
+++ b/aegis/auth/dto.go
@@ -16,6 +16,9 @@ type LoginRequest struct {
 	// 身份主体（用户名/邮箱/手机号/OpenID...）
 	Principal string `json:"principal,omitempty"`
 
+	// 认证会话 ID（如 Passkey/WebAuthn ceremony uid）
+	UID string `json:"uid,omitempty"`
+
 	// 凭证证明（any 类型，由各 authenticator 自行解析）
 	// 可能是 string（password/OTP/captcha token）或复杂对象（OAuth 回调数据等）
 	Proof any `json:"proof,omitempty"`
@@ -34,8 +37,8 @@ func (r LoginRequest) String() string {
 			proofHint = fmt.Sprintf("<%T>", v)
 		}
 	}
-	return fmt.Sprintf("{Connection: %s, Strategy: %s, Principal: %s, Proof: %s}",
-		r.Connection, r.Strategy, maskPrincipal(r.Principal), proofHint)
+	return fmt.Sprintf("{Connection: %s, Strategy: %s, Principal: %s, UID: %s, Proof: %s}",
+		r.Connection, r.Strategy, maskPrincipal(r.Principal), r.UID, proofHint)
 }
 
 func maskPrincipal(s string) string {
@@ -55,6 +58,23 @@ func maskPrincipal(s string) string {
 // LoginResponse 登录响应
 type LoginResponse struct {
 	Location string `json:"location"` // 重定向地址（携带 code 和 state）
+}
+
+// IDPInitiateRequest IDP 认证入口请求
+type IDPInitiateRequest struct {
+	Connection string `json:"connection" binding:"required"`
+	Strategy   string `json:"strategy,omitempty"`
+}
+
+// IDPInitiateResponse IDP 认证入口响应
+type IDPInitiateResponse struct {
+	Connection string         `json:"connection"`
+	Mode       string         `json:"mode"`
+	UID        string         `json:"uid,omitempty"`
+	URL        string         `json:"url,omitempty"`
+	Action     string         `json:"action,omitempty"`
+	Params     map[string]any `json:"params,omitempty"`
+	Options    any            `json:"options,omitempty"`
 }
 
 // RevokeRequest 撤销请求

--- a/aegis/auth/handler.go
+++ b/aegis/auth/handler.go
@@ -344,6 +344,55 @@ func (h *Handler) Login(c *gin.Context) {
 	actionRedirect(c, buildAuthCodeRedirectURL(flow.Request.RedirectURI, authCode))
 }
 
+// --- IDP authentication entry ---
+
+type idpInitiator interface {
+	Initiate(ctx context.Context, strategy string) (*idp.InitiateResponse, error)
+}
+
+// IDPs POST /auth/idps
+func (h *Handler) IDPs(c *gin.Context) {
+	var req IDPInitiateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.errorResponse(c, autherrors.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	ctx := helpers.WithRemoteIP(c.Request.Context(), c.ClientIP())
+	flow := h.loadAuthFlow(c, ctx)
+	if flow == nil {
+		return
+	}
+	defer h.saveFlow(ctx, flow)
+
+	if err := ensureIDPEnabled(flow, req.Connection); err != nil {
+		h.errorResponse(c, err)
+		return
+	}
+
+	initiator, err := h.idpInitiator(req.Connection)
+	if err != nil {
+		h.errorResponse(c, err)
+		return
+	}
+
+	resp, err := initiator.Initiate(ctx, req.Strategy)
+	if err != nil {
+		h.errorResponse(c, autherrors.NewServerErrorf("idp initiate failed: %v", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, &IDPInitiateResponse{
+		Connection: req.Connection,
+		Mode:       resp.Mode,
+		UID:        resp.UID,
+		URL:        resp.URL,
+		Action:     resp.Action,
+		Params:     resp.Params,
+		Options:    resp.Options,
+	})
+}
+
 // --- Challenge ---
 
 // InitiateChallenge POST /auth/challenge
@@ -953,7 +1002,7 @@ func (h *Handler) authenticate(c *gin.Context, ctx context.Context, flow *types.
 			return false, nil
 		}
 
-		success, err := h.authenticateSvc.Authenticate(ctx, flow, req.Proof, req.Principal, req.Strategy)
+		success, err := h.authenticateSvc.Authenticate(ctx, flow, req.Proof, req.Principal, req.Strategy, req.UID)
 		if err != nil {
 			return false, err
 		}
@@ -1216,6 +1265,11 @@ func (h *Handler) handleMainVerification(c *gin.Context, ctx context.Context, ch
 		return
 	}
 
+	if ch.Channel == "" {
+		h.errorResponse(c, autherrors.NewServerError("challenge subject is empty"))
+		return
+	}
+
 	if err = h.challengeSvc.Delete(ctx, ch.ID); err != nil {
 		logger.Warnf("[验证 Challenge] 删除 Challenge 失败: %v", err)
 	}
@@ -1240,6 +1294,47 @@ func (h *Handler) handleMainVerification(c *gin.Context, ctx context.Context, ch
 		ChallengeToken: tokenStr,
 		ExpiresIn:      int(ch.ExpiresIn().Seconds()),
 	})
+}
+
+func (h *Handler) loadAuthFlow(c *gin.Context, ctx context.Context) *types.AuthFlow {
+	flowID, err := getAuthSessionCookie(c)
+	if err != nil || flowID == "" {
+		h.errorResponse(c, autherrors.NewFlowNotFound("missing session"))
+		return nil
+	}
+
+	flow := h.authenticateSvc.GetAndValidateFlow(ctx, flowID)
+	if flow.Failed() {
+		h.flowErrorResponse(c, flow)
+		return nil
+	}
+	return flow
+}
+
+func (h *Handler) saveFlow(ctx context.Context, flow *types.AuthFlow) {
+	if err := h.authenticateSvc.SaveFlow(ctx, flow); err != nil {
+		logger.Warnf("[Handler] 保存 flow 失败: %v", err)
+	}
+}
+
+func (h *Handler) idpInitiator(connection string) (idpInitiator, error) {
+	auth, ok := authenticator.GlobalRegistry().Get(connection)
+	if !ok {
+		return nil, autherrors.NewInvalidRequestf("connection %s is not configured", connection)
+	}
+	initiator, ok := auth.(idpInitiator)
+	if !ok {
+		return nil, autherrors.NewInvalidRequestf("connection %s does not support idp initiate", connection)
+	}
+	return initiator, nil
+}
+
+func ensureIDPEnabled(flow *types.AuthFlow, connection string) error {
+	cfg := flow.ConnectionMap[connection]
+	if cfg == nil || cfg.Type != types.ConnTypeIDP {
+		return autherrors.NewInvalidRequestf("connection %s is not enabled for this application", connection)
+	}
+	return nil
 }
 
 func (h *Handler) initiateChallenge(ctx context.Context, ch *types.Challenge) error {

--- a/aegis/internal/authenticate/factor.go
+++ b/aegis/internal/authenticate/factor.go
@@ -141,7 +141,7 @@ func (a *FactorAuthenticator) Initiate(ctx context.Context, challenge *types.Cha
 
 // Verify 验证 Challenge proof（委托 factor.Provider.Verify）
 func (a *FactorAuthenticator) Verify(ctx context.Context, challenge *types.Challenge, proof string) (bool, error) {
-	return a.provider.Verify(ctx, proof, challenge.Channel, challenge.ID)
+	return a.provider.Verify(ctx, challenge, proof)
 }
 
 // probeRate 检查限流（IP + Channel 维度），结果写入 challenge.RetryAfter

--- a/aegis/internal/authenticate/idp.go
+++ b/aegis/internal/authenticate/idp.go
@@ -97,6 +97,15 @@ func (a *IDPAuthenticator) Resolve(ctx context.Context, principal string) (*mode
 	return a.provider.Resolve(ctx, principal)
 }
 
+// Initiate 执行 IDP 认证入口初始化。
+func (a *IDPAuthenticator) Initiate(ctx context.Context, strategy string) (*idp.InitiateResponse, error) {
+	provider, ok := a.provider.(idp.Initiator)
+	if !ok {
+		return nil, autherrors.NewInvalidRequestf("provider %s does not support idp initiate", a.provider.Type())
+	}
+	return provider.Initiate(ctx, strategy)
+}
+
 // ==================== Exchanger 实现（条件） ====================
 
 // Exchange 用平台授权码换取 principal（如小程序 code 换手机号）

--- a/aegis/internal/authenticate/service.go
+++ b/aegis/internal/authenticate/service.go
@@ -102,7 +102,7 @@ func (s *Service) SaveFlow(ctx context.Context, flow *types.AuthFlow) error {
 
 // Authenticate 执行认证
 // 调用方需先完成 flow.SetConnection 设置当前 Connection
-// params 约定顺序：proof, principal, strategy
+// params 约定顺序：proof, principal, strategy, uid
 // remoteIP 通过 context 传递（ctxutil.WithRemoteIP）
 //
 // Strike 后置：仅在认证失败后计数，达阈值时返回 TooManyRequests error（429 + retry_after）

--- a/aegis/internal/authenticator/factor/email_otp.go
+++ b/aegis/internal/authenticator/factor/email_otp.go
@@ -47,22 +47,16 @@ func (p *EmailOTPProvider) Initiate(ctx context.Context, challenge *types.Challe
 
 // Verify 验证邮件验证码
 // proof: OTP 验证码
-// params[0]: channel (string) - 邮箱地址（未使用，但统一传入）
-// params[1]: challengeID (string) - 用于从 cache 获取已存储的 OTP
-func (p *EmailOTPProvider) Verify(ctx context.Context, proof string, params ...any) (bool, error) {
+func (p *EmailOTPProvider) Verify(ctx context.Context, challenge *types.Challenge, proof string) (bool, error) {
 	if proof == "" {
 		return false, nil
 	}
 
-	if len(params) < 2 {
-		return false, nil
-	}
-	challengeID, ok := params[1].(string)
-	if !ok || challengeID == "" {
+	if challenge == nil || challenge.ID == "" {
 		return false, nil
 	}
 
-	otpKey := types.CacheKeyPrefixEmailOTP + challengeID
+	otpKey := types.CacheKeyPrefixEmailOTP + challenge.ID
 	storedCode, err := p.cache.GetOTP(ctx, otpKey)
 	if err != nil {
 		return false, nil

--- a/aegis/internal/authenticator/factor/provider.go
+++ b/aegis/internal/authenticator/factor/provider.go
@@ -24,8 +24,7 @@ type Provider interface {
 
 	// Verify 验证认证因子凭证
 	// proof: 验证凭证（OTP code / WebAuthn response 等）
-	// params: 额外参数（如 challengeID、channel 等）
-	Verify(ctx context.Context, proof string, params ...any) (bool, error)
+	Verify(ctx context.Context, challenge *types.Challenge, proof string) (bool, error)
 
 	// Prepare 准备前端所需的公开配置
 	Prepare() *types.ConnectionConfig

--- a/aegis/internal/authenticator/factor/totp.go
+++ b/aegis/internal/authenticator/factor/totp.go
@@ -41,21 +41,16 @@ func (p *TOTPFactor) Initiate(_ context.Context, challenge *types.Challenge) err
 
 // Verify 验证 TOTP 验证码
 // proof: TOTP 码
-// params[0]: openid (string)
-func (p *TOTPFactor) Verify(ctx context.Context, proof string, params ...any) (bool, error) {
+func (p *TOTPFactor) Verify(ctx context.Context, challenge *types.Challenge, proof string) (bool, error) {
 	if proof == "" {
 		return false, nil
 	}
 
-	if len(params) < 1 {
-		return false, nil
-	}
-	openid, ok := params[0].(string)
-	if !ok || openid == "" {
+	if challenge == nil || challenge.Channel == "" {
 		return false, nil
 	}
 
-	return p.verifier.VerifyCode(ctx, openid, proof)
+	return p.verifier.VerifyCode(ctx, challenge.Channel, proof)
 }
 
 // Prepare 准备前端公开配置

--- a/aegis/internal/authenticator/factor/webauthn.go
+++ b/aegis/internal/authenticator/factor/webauthn.go
@@ -39,12 +39,7 @@ func (p *WebAuthnProvider) Initiate(ctx context.Context, challenge *types.Challe
 	}
 
 	if challenge.Channel == "" {
-		options, err := p.webauthnSvc.InitializeDiscoverableAuthenticationCeremony(ctx, challenge.ID, challenge.ExpiresIn())
-		if err != nil {
-			return err
-		}
-		challenge.SetData(types.ChallengeDataOptions, options)
-		return err
+		return fmt.Errorf("channel is required for webauthn factor")
 	}
 
 	user, err := p.resolveUser(ctx, challenge.Channel)
@@ -67,26 +62,17 @@ func (p *WebAuthnProvider) Initiate(ctx context.Context, challenge *types.Challe
 
 // Verify 验证 WebAuthn 凭证
 // proof: WebAuthn assertion JSON（前端 navigator.credentials.get() 序列化结果）
-// params[0]: channel (string) - user_id（未使用，但统一传入）
-// params[1]: challengeID (string)
-func (p *WebAuthnProvider) Verify(ctx context.Context, proof string, params ...any) (bool, error) {
+func (p *WebAuthnProvider) Verify(ctx context.Context, challenge *types.Challenge, proof string) (bool, error) {
 	if proof == "" {
 		return false, fmt.Errorf("webauthn assertion is required")
 	}
 
-	// 从 params 获取 challengeID
-	var challengeID string
-	if len(params) > 1 {
-		if id, ok := params[1].(string); ok {
-			challengeID = id
-		}
-	}
-	if challengeID == "" {
+	if challenge == nil || challenge.ID == "" {
 		return false, fmt.Errorf("challenge_id is required")
 	}
 
 	// 完成 WebAuthn 验证（从 proof 解析 assertion，不依赖 *http.Request）
-	_, credential, err := p.webauthnSvc.VerifyAuthentication(ctx, challengeID, []byte(proof))
+	_, credential, err := p.webauthnSvc.VerifyAuthentication(ctx, challenge.ID, []byte(proof))
 	if err != nil {
 		logger.Errorf("[WebAuthn Factor] VerifyAuthentication failed: %v", err)
 		return false, fmt.Errorf("webauthn verification failed: %w", err)

--- a/aegis/internal/authenticator/idp/passkey/provider.go
+++ b/aegis/internal/authenticator/idp/passkey/provider.go
@@ -36,47 +36,30 @@ func (*Provider) Type() string {
 	return TypePasskey
 }
 
-// Login 执行 Passkey 登录
-// proof: WebAuthn assertion JSON（前端 navigator.credentials.get() 序列化结果，包含 challengeID）
-// params[0]: principal（忽略）
-// params[1]: strategy（忽略）
+// Login 执行 Passkey 登录。
+// proof: WebAuthn assertion JSON
+// params[0]: appID（由 IDPAuthenticator 注入，Passkey 不使用）
+// params[1]: principal（忽略）
+// params[2]: strategy（忽略）
+// params[3]: uid（由 Initiate 返回的 ceremony uid）
 func (p *Provider) Login(ctx context.Context, proof string, params ...any) (*models.TUserInfo, error) {
-	if proof == "" {
-		return nil, fmt.Errorf("webauthn assertion is required")
+	uid := stringParam(params, 3)
+	if uid == "" {
+		return nil, fmt.Errorf("uid is required")
 	}
+	return p.verify(ctx, uid, proof)
+}
 
-	// proof 即 assertion JSON，从中提取 challengeID
-	// TODO: challengeID 应从 assertion 或 params 中获取，当前暂用 principal 传递
-	var challengeID string
-	if len(params) > 0 {
-		if id, ok := params[0].(string); ok && id != "" {
-			challengeID = id
-		}
-	}
-	if challengeID == "" {
-		return nil, fmt.Errorf("challenge_id is required (pass via principal)")
-	}
-
-	// 完成 WebAuthn 登录验证（从 proof 解析 assertion，不依赖 *http.Request）
-	userID, credential, err := p.webauthnSvc.VerifyAuthentication(ctx, challengeID, []byte(proof))
+// Initiate 初始化 Passkey discoverable ceremony。
+func (p *Provider) Initiate(ctx context.Context, _ string) (*idp.InitiateResponse, error) {
+	options, err := p.InitializeLogin(ctx)
 	if err != nil {
-		logger.Errorf("[Passkey] VerifyAuthentication failed: %v", err)
-		return nil, fmt.Errorf("passkey authentication failed: %w", err)
+		return nil, err
 	}
-
-	// 更新凭证签名计数（防重放）
-	if credential != nil {
-		credentialID := base64.RawURLEncoding.EncodeToString(credential.ID)
-		if err := p.webauthnSvc.PatchCredentialSignCount(ctx, credentialID, credential.Authenticator.SignCount); err != nil {
-			logger.Warnf("[Passkey] PatchCredentialSignCount failed: %v", err)
-		}
-	}
-
-	logger.Infof("[Passkey] Login success - UserID: %s", userID)
-
-	return &models.TUserInfo{
-		TOpenID: userID,
-		RawData: fmt.Sprintf(`{"user_id":"%s","challenge_id":"%s"}`, userID, challengeID),
+	return &idp.InitiateResponse{
+		Mode:    "webauthn",
+		UID:     options.CeremonyID,
+		Options: options.Options,
 	}, nil
 }
 
@@ -110,4 +93,42 @@ func (p *Provider) InitializeLogin(ctx context.Context) (*webauthn.Authenticatio
 		Options:    options,
 		CeremonyID: ceremonyID,
 	}, nil
+}
+
+func (p *Provider) verify(ctx context.Context, uid, proof string) (*models.TUserInfo, error) {
+	if uid == "" {
+		return nil, fmt.Errorf("uid is required")
+	}
+	if proof == "" {
+		return nil, fmt.Errorf("webauthn assertion is required")
+	}
+
+	userID, credential, err := p.webauthnSvc.VerifyAuthentication(ctx, uid, []byte(proof))
+	if err != nil {
+		logger.Errorf("[Passkey] VerifyAuthentication failed: %v", err)
+		return nil, fmt.Errorf("passkey authentication failed: %w", err)
+	}
+
+	if credential != nil {
+		credentialID := base64.RawURLEncoding.EncodeToString(credential.ID)
+		if err := p.webauthnSvc.PatchCredentialSignCount(ctx, credentialID, credential.Authenticator.SignCount); err != nil {
+			logger.Warnf("[Passkey] PatchCredentialSignCount failed: %v", err)
+		}
+	}
+
+	return &models.TUserInfo{
+		TOpenID: userID,
+		RawData: fmt.Sprintf(`{"user_id":"%s","type":"passkey","uid":"%s"}`, userID, uid),
+	}, nil
+}
+
+func stringParam(params []any, index int) string {
+	if len(params) <= index {
+		return ""
+	}
+	value, ok := params[index].(string)
+	if !ok {
+		return ""
+	}
+	return value
 }

--- a/aegis/internal/authenticator/idp/provider.go
+++ b/aegis/internal/authenticator/idp/provider.go
@@ -32,6 +32,22 @@ type Provider interface {
 	Prepare() *types.ConnectionConfig
 }
 
+// Initiator 是 IDP 的认证入口能力。
+// 用于 OAuth redirect、Passkey ceremony、小程序 client action 等登录前置交互。
+type Initiator interface {
+	Initiate(ctx context.Context, strategy string) (*InitiateResponse, error)
+}
+
+// InitiateResponse IDP 认证入口响应。
+type InitiateResponse struct {
+	Mode    string         `json:"mode"`
+	UID     string         `json:"uid,omitempty"`
+	URL     string         `json:"url,omitempty"`
+	Action  string         `json:"action,omitempty"`
+	Params  map[string]any `json:"params,omitempty"`
+	Options any            `json:"options,omitempty"`
+}
+
 // AdditionalInfo 补充信息结果
 type AdditionalInfo struct {
 	Type  string         `json:"type"`            // "phone", "email" 等

--- a/aegis/main.go
+++ b/aegis/main.go
@@ -87,6 +87,7 @@ func main() {
 			{"GET", "/connections", aegisHandler.GetConnections},
 			{"GET", "/context", aegisHandler.GetContext},
 			{"POST", "/login", aegisHandler.Login},
+			{"POST", "/idps", aegisHandler.IDPs},
 			{"GET", "/binding", aegisHandler.GetIdentifyContext},
 			{"POST", "/binding", aegisHandler.ConfirmIdentify},
 			{"POST", "/challenge", aegisHandler.InitiateChallenge},

--- a/docs/webauthn-login.md
+++ b/docs/webauthn-login.md
@@ -41,8 +41,9 @@
 │  POST /auth/authorize    → authenticateSvc.CreateFlow()                  │
 │  GET  /auth/connections  → authenticateSvc.GetAvailableConnections()     │
 │  GET  /auth/context      → flow.Application / flow.Service               │
-│  POST /auth/challenge    → challengeSvc.Initiate() [WebAuthn begin]     │
-│  POST /auth/challenge/:cid → challengeSvc.VerifyProof() [assertion]     │
+│  POST /auth/idps          → passkey.Provider.Initiate()                  │
+│  POST /auth/challenge    → challengeSvc.Initiate() [Factor begin]       │
+│  POST /auth/challenge/:cid → challengeSvc.VerifyProof() [Factor proof]  │
 │  POST /auth/login        → authenticateSvc.Authenticate()                │
 │                                                                          │
 ├──────────────────────────────────────────────────────────────────────────┤
@@ -236,42 +237,18 @@ heliannuuthus@aegis:passkey_user
 ### 6.3 Passkey 登录完整时序
 
 ```
-┌──────────┐      ┌──────────┐      ┌──────────┐      ┌──────────┐
-│  前端     │      │ /challenge│      │/challenge│      │ /login   │
-│ (pallas)  │      │  (POST)  │      │  /:cid   │      │  (POST)  │
-└────┬─────┘      └────┬─────┘      └────┬─────┘      └────┬─────┘
-     │                  │                  │                  │
-     │ 1. initiateChallenge               │                  │
-     │  { client_id, audience,            │                  │
-     │    type: "login",                  │                  │
-     │    channel_type: "webauthn" }      │                  │
-     ├─────────────────►│                  │                  │
-     │                  │                  │                  │
-     │  { challenge_id, │                  │                  │
-     │    options }     │                  │                  │
-     │◄─────────────────┤                  │                  │
-     │                  │                  │                  │
-     │ 2. convertToPublicKeyOptions()     │                  │
-     │    navigator.credentials.get()     │                  │
-     │    [用户触摸指纹/面容]               │                  │
-     │    convertAssertionResponse()      │                  │
-     │                  │                  │                  │
-     │ 3. continueChallenge(cid,          │                  │
-     │    { proof: assertionJSON })       │                  │
-     ├────────────────────────────────────►│                  │
-     │                  │                  │                  │
-     │  { verified: true,                 │                  │
-     │    challenge_token }               │                  │
-     │◄────────────────────────────────────┤                  │
-     │                  │                  │                  │
-     │ 4. login({ connection: "passkey",  │                  │
-     │    proof: challenge_token })       │                  │
-     ├───────────────────────────────────────────────────────►│
-     │                  │                  │                  │
-     │  { location: redirect_uri?code=xxx }                  │
-     │◄───────────────────────────────────────────────────────┤
-     │                  │                  │                  │
-     │ 5. window.location.href = location │                  │
+1. POST /auth/idps
+   { connection: "passkey" }
+   -> { connection: "passkey", mode: "webauthn", uid, options }
+
+2. 前端执行 WebAuthn
+   convertToPublicKeyOptions(options)
+   navigator.credentials.get()
+   convertAssertionResponse()
+
+3. POST /auth/login
+   { connection: "passkey", uid, proof: assertionJSON }
+   -> { location: redirect_uri?code=xxx }
 ```
 
 ### 6.4 遮盖层组件结构与交互设计
@@ -367,10 +344,11 @@ Registry 中每个 `Authenticator` 实现基础的认证接口（`Type()` / `Con
 
 | 能力接口 | 适用场景 | 发现方式 | 实现者 |
 |---------|---------|---------|--------|
-| `ChallengeVerifier` | 需要两阶段验证的方式（先发起 → 再验证） | 类型断言 | Factor（WebAuthn / Email OTP / TOTP）、VChan |
+| `ChallengeVerifier` | 需要两阶段验证的 factor（先发起 → 再验证） | 类型断言 | Factor（WebAuthn / Email OTP / TOTP）、VChan |
 | `ChallengeExchanger` | 需要一步交换的方式（如小程序 code 换手机号） | 类型断言 | 部分 IDP |
 
 `challengeSvc` 通过类型断言（`authenticator.(ChallengeVerifier)`）发现当前 Authenticator 是否具备 Challenge 能力，而非硬编码依赖。
+Passkey 是独立 IDP，使用 `/auth/idps` 初始化 ceremony，然后通过 `/auth/login` 直接提交 assertion，不复用普通 factor challenge。
 
 #### Initiate 阶段（创建 Challenge）
 
@@ -381,13 +359,13 @@ POST /auth/challenge
       → 从 Registry 获取 channel_type 对应的 Authenticator
       → 类型断言为 ChallengeVerifier
       → 调用 verifier.Initiate(ctx, challenge)
-          → WebAuthn: 根据 channel 是否为空选择 DiscoverableLogin 或 Login
+          → WebAuthn: 根据 channel 查找用户并创建 Login ceremony
           → 将 WebAuthn session 数据写入 Challenge.Data
   → challengeSvc.Save(): 序列化 Challenge 到 Redis（含 session 数据）
   → Handler: 返回 challenge_id + options
 ```
 
-**channel 路由规则**：当 `channel` 为空串时，WebAuthn Provider 调用 `BeginDiscoverableLogin()`（Passkey 场景，无需预知用户）；当 `channel` 非空（为用户邮箱或 ID）时，调用 `BeginLogin()`（Factor 场景，指定用户的 `allowCredentials`）。
+**channel 路由规则**：普通 WebAuthn factor 必须带 `channel`（用户邮箱或 ID），后端据此构建该用户的 `allowCredentials`。无用户上下文的 discoverable ceremony 只属于 Passkey IDP，不走 `/auth/challenge`。
 
 #### Verify 阶段（验证 Challenge）
 
@@ -398,23 +376,23 @@ POST /auth/challenge/:cid
       → 从 Registry 获取 Authenticator → 类型断言为 ChallengeVerifier
       → 调用 verifier.Verify(ctx, challenge, proof)
           → WebAuthn: 解析 assertion JSON → 调用 FinishLogin
-          → 通过 credential ID 反查用户 OpenID
   → Handler: 签发 challenge_token（PASETO v4.public 格式）
-      → Claims: { sub: openid, aud: audience, exp: +5min, challenge_id: cid }
+      → Claims: { sub: channel, aud: audience, exp: +5min }
 ```
 
-**Session 传递机制**：WebAuthn 协议要求 `BeginLogin` 和 `FinishLogin` 之间共享 session 数据（包含 challenge nonce、expected credentials 等）。本方案将 session 数据序列化后存入 `Challenge.Data["session"]`，随 Challenge 对象一起持久化到 Redis。Verify 阶段从 Redis 加载 Challenge 时自动恢复 session，TTL 为 5 分钟。
+**Session 传递机制**：WebAuthn 协议要求 `BeginLogin` 和 `FinishLogin` 之间共享 session 数据（包含 challenge nonce、expected credentials 等）。本方案将 WebAuthn ceremony 数据以 `challenge_id` 为 key 存入 Redis。Verify 阶段通过 path 中的 `challenge_id` 恢复 ceremony，TTL 为 5 分钟。
 
-#### Login 阶段
+#### Passkey Login 阶段
 
 ```
-POST /auth/login { connection: "passkey", proof: challenge_token }
+POST /auth/login { connection: "passkey", uid, proof: assertionJSON }
   → Handler: 获取 AuthFlow，设置当前 connection
   → authenticateSvc.Authenticate()
       → 从 Registry 获取 "passkey" → IDPAuthenticator
       → 调用 passkey.Provider.Login()
-          → 验证 challenge_token 的 PASETO 签名和有效期
-          → 从 token claims 中提取用户 OpenID
+          → 用 uid 恢复 WebAuthn ceremony
+          → 验证 assertion 签名、origin、rpId、challenge 和 signCount
+          → 从 credential 反查用户 OpenID
           → 返回 UserInfo
   → Handler: 解析用户身份 → 签发 authorization code → 返回 redirect location
 ```
@@ -423,13 +401,11 @@ POST /auth/login { connection: "passkey", proof: challenge_token }
 
 ```
 LoginRequest {
-  connection: "passkey"    → flow.SetConnection("passkey")
-  proof:      challenge_token → passkey.Provider.Login(ctx, proof, principal, strategy)
-  principal:  challenge_id    → 用于关联 WebAuthn session（当前通过 params[0] 传递）
+  connection: "passkey"       → flow.SetConnection("passkey")
+  uid:        ceremony uid     → passkey.Provider.Login(ctx, proof, ..., uid)
+  proof:      assertionJSON    → passkey.Provider.Login(ctx, proof, ..., uid)
 }
 ```
-
-> TODO：`challengeID` 当前暂用 `principal` 参数传递，后续应从 `challenge_token` claims 中直接提取。
 
 ## 8. 失败与降级策略
 
@@ -613,7 +589,7 @@ Challenge 验证（`challenge/service.go`）有独立的访问控制链：
   "audience": "svc_xxx",
   "type": "login",
   "channel_type": "webauthn",
-  "channel": ""
+  "channel": "user@example.com"
 }
 ```
 
@@ -623,7 +599,7 @@ Challenge 验证（`challenge/service.go`）有独立的访问控制链：
 | `audience` | string | 是 | 目标服务 ID |
 | `type` | string | 验证类可选 | 业务场景（`login` / `bind` / `verify` 等） |
 | `channel_type` | string | 是 | 验证方式（`webauthn` / `email-code` / `totp`） |
-| `channel` | string | 是 | 验证目标（Passkey 登录时为空串，WebAuthn Factor 时为邮箱） |
+| `channel` | string | 是 | 验证目标（邮箱 / 手机号 / user_id / wx_code ...；WebAuthn Factor 为邮箱或用户 ID） |
 
 响应：
 
@@ -696,6 +672,27 @@ WebAuthn 类型的响应会额外包含 `options`（`PublicKeyCredentialRequestO
 
 ### 13.2 Login API
 
+#### `POST /auth/idps` — IDP 认证入口
+
+Passkey 入口请求：
+
+```json
+{
+  "connection": "passkey"
+}
+```
+
+Passkey 入口响应：
+
+```json
+{
+  "connection": "passkey",
+  "mode": "webauthn",
+  "uid": "ch_xxx",
+  "options": {}
+}
+```
+
 #### `POST /auth/login` — 登录
 
 Passkey 登录请求：
@@ -703,7 +700,8 @@ Passkey 登录请求：
 ```json
 {
   "connection": "passkey",
-  "proof": "v4.public.challenge_token_xxx..."
+  "uid": "ch_xxx",
+  "proof": "{\"id\":\"...\",\"rawId\":\"...\",\"response\":{...},\"type\":\"public-key\"}"
 }
 ```
 
@@ -733,7 +731,8 @@ Staff Delegate（WebAuthn/Email OTP）登录请求：
 | `connection` | string | 是 | 连接标识（`passkey` / `staff` / `github` 等） |
 | `strategy` | string | 否 | 认证策略（仅 `staff` 的 `password` 策略需要） |
 | `principal` | string | 否 | 身份标识（邮箱；Passkey 登录不需要） |
-| `proof` | any | 是 | 认证凭证（密码 / challenge_token） |
+| `uid` | string | 否 | 认证会话 ID（Passkey 登录必填） |
+| `proof` | any | 是 | 认证凭证（密码 / challenge_token / WebAuthn assertion） |
 
 成功响应：
 
@@ -907,7 +906,7 @@ WebAuthn Delegate 登录发生在 `VerifyStep` 组件中，用户已经在上一
 
 #### 与 Passkey IDP 流程的关键差异点
 
-- **步骤 1**：Passkey IDP 的 `channel` 为空串，WebAuthn Factor 的 `channel` 为用户邮箱
+- **步骤 1**：Passkey IDP 走 `/auth/idps`，没有 `channel` 入参；WebAuthn Factor 走 `/auth/challenge`，`channel` 为用户邮箱
 - **步骤 2**：Passkey IDP 响应的 `allowCredentials` 为空（让浏览器/认证器自选），Factor 响应的 `allowCredentials` 列出该用户的所有已注册凭证 ID
 - **步骤 4**：Passkey IDP 的 `connection` 为 `"passkey"` 且不需要 `principal`，Factor 的 `connection` 为 `"staff"` 且需要 `principal`（邮箱）
 
@@ -922,7 +921,8 @@ WebAuthn Delegate 登录发生在 `VerifyStep` 组件中，用户已经在上一
 
 | 维度 | Passkey IDP | WebAuthn Factor (Staff Delegate) |
 |------|-------------|--------------------------------|
-| `channel` | 空串 | 用户邮箱（已在邮箱步骤确认） |
+| 初始化入口 | `/auth/idps` | `/auth/challenge` |
+| `channel` | 无 | 用户邮箱（已在邮箱步骤确认） |
 | `allowCredentials` | 空（Discoverable） | 非空（指定用户的已注册凭证） |
 | `login.connection` | `"passkey"` | `"staff"` |
 | `login.principal` | 不需要 | 用户邮箱 |
@@ -945,12 +945,10 @@ Staff Provider 对 delegate 的处理是**token 来源无关**的——无论 ch
 
 ## 15. 已知问题与后续优化
 
-1. **challengeID 传递方式**：当前 Passkey 登录通过 `principal` 参数传递 `challengeID`，语义不够清晰。后续应直接从 `challenge_token` 的 JWT claims 中提取，消除对 `principal` 的滥用。
+1. **凭证失效未清缓存**：`SecurityMask` 中检测到凭证不存在时仅关闭遮盖层，未调用 `passkeyUserCache.clear()`。下次访问仍会展示遮盖层。
 
-2. **凭证失效未清缓存**：`SecurityMask` 中检测到凭证不存在时仅关闭遮盖层，未调用 `passkeyUserCache.clear()`。下次访问仍会展示遮盖层。
+2. **缓存过期策略**：当前 `updated_at` 字段仅用于调试，未实现自动过期。建议设定合理的 TTL（如 90 天），超期不展示遮盖层。
 
-3. **缓存过期策略**：当前 `updated_at` 字段仅用于调试，未实现自动过期。建议设定合理的 TTL（如 90 天），超期不展示遮盖层。
+3. **多设备场景**：用户在设备 A 注册 Passkey 后在设备 B 登录，设备 B 无缓存不会显示遮盖层，但 Conditional UI（如果支持）可作为备选入口。
 
-4. **多设备场景**：用户在设备 A 注册 Passkey 后在设备 B 登录，设备 B 无缓存不会显示遮盖层，但 Conditional UI（如果支持）可作为备选入口。
-
-5. **Passkey 注册时的暂存依赖**：`setPendingUserInfo()` 依赖调用方（`SecuritySettings`）在注册前主动暂存。如果个人信息页重构，需确保此调用链不断。
+4. **Passkey 注册时的暂存依赖**：`setPendingUserInfo()` 依赖调用方（`SecuritySettings`）在注册前主动暂存。如果个人信息页重构，需确保此调用链不断。

--- a/hermes/sql/init.sql
+++ b/hermes/sql/init.sql
@@ -96,8 +96,7 @@ ON DUPLICATE KEY UPDATE relation = VALUES(relation);
 -- ==================== 服务 Challenge 配置 ====================
 INSERT INTO t_service_challenge_setting (service_id, `type`, expires_in, limits) VALUES
 ('iris', 'staff:verify', 300, '{"1m": 1, "24h": 10}'),
-('iris', 'user:verify', 300, '{"1m": 1, "24h": 10}'),
-('iris', 'passkey:verify', 300, '{"1m": 1, "24h": 10}')
+('iris', 'user:verify', 300, '{"1m": 1, "24h": 10}')
 ON DUPLICATE KEY UPDATE expires_in = VALUES(expires_in), limits = VALUES(limits);
 
 -- ==================== 用户 ====================

--- a/scripts/initialize-hermes.py
+++ b/scripts/initialize-hermes.py
@@ -332,7 +332,6 @@ APP_SERVICE_RELATIONS = [
 SERVICE_CHALLENGE_SETTINGS = [
     ServiceChallengeSetting("iris", "staff:verify", expires_in=300, limits={"1m": 1, "24h": 10}),
     ServiceChallengeSetting("iris", "user:verify", expires_in=300, limits={"1m": 1, "24h": 10}),
-    ServiceChallengeSetting("iris", "passkey:verify", expires_in=300, limits={"1m": 1, "24h": 10}),
 ]
 
 _admin_openid = "11ffa2fb5bfa3b8f8e805d88c479f306"


### PR DESCRIPTION
## Summary
- replace passkey-specific /auth/passkey/pre and /auth/passkey/verify with generic POST /auth/idps
- pass LoginRequest.uid through the authenticate pipeline so /auth/login can consume Passkey WebAuthn assertions directly
- keep /auth/challenge scoped to factor/delegate flows; remove the stale passkey:verify challenge setting
- simplify passkey provider so it owns WebAuthn entry/login verification without issuing challenge_token
- update WebAuthn/Passkey docs to reflect the new IDP vs factor boundary

## Test plan
- go test ./...
- golangci-lint run --fix ./...
- make build SERVICE=aegis