### PR TITLE
feat: add Hermes domain provisioning API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ export PATH := $(HOME)/.asdf/shims:$(HOME)/.go/bin:$(HOME)/.cargo/bin:$(PATH)
 SERVICES := hermes aegis zwei chaos
 MODULES  := proto pkg $(SERVICES)
 
+GO_TOOLCHAIN            := $(shell go env GOVERSION)
+GOLANGCI_LINT_VERSION  ?= v2.12.2
+GOLANGCI_LINT_DIR       := $(CURDIR)/bin/tools/$(GO_TOOLCHAIN)/$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT           := $(GOLANGCI_LINT_DIR)/golangci-lint
+
 ifneq ($(CONTAINER_RUNTIME),)
 CTR := $(CONTAINER_RUNTIME)
 else ifneq ($(shell command -v nerdctl 2>/dev/null),)
@@ -66,8 +71,15 @@ run: build
 test:
 	@for m in $(MODULES); do (cd $$m && go test ./...); done
 
-lint:
-	@for m in $(MODULES); do (cd $$m && golangci-lint run --fix ./...); done
+$(GOLANGCI_LINT):
+	@echo "[tools] install golangci-lint $(GOLANGCI_LINT_VERSION) with $(GO_TOOLCHAIN)"
+	@mkdir -p "$(GOLANGCI_LINT_DIR)"
+	@GOBIN="$(GOLANGCI_LINT_DIR)" GOTOOLCHAIN="$(GO_TOOLCHAIN)" \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+lint: $(GOLANGCI_LINT)
+	@$(GOLANGCI_LINT) version
+	@for m in $(MODULES); do (cd $$m && $(GOLANGCI_LINT) run --fix ./...); done
 
 fmt:
 	@for m in $(MODULES); do (cd $$m && go fmt ./...); done

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ ps:
 
 dev: dev-up
 
-dev-up: dev-check build
+dev-up: dev-check _dev-stop-processes build
 	@command -v $(CTR) >/dev/null || { echo "[dev] ERROR: 未找到 $(CTR)"; exit 1; }
 	@$(CTR) info >/dev/null 2>&1 || { echo "[dev] ERROR: $(CTR) daemon 未运行"; exit 1; }
 	@has_prod=false; for s in aegis hermes zwei chaos; do \
@@ -248,27 +248,24 @@ dev-up: dev-check build
 	@mkdir -p $(DEV_PID)
 	@set -e; \
 	log() { echo "[dev] $$*"; }; \
-	service_running() { \
-		s=$$1; pid_file="$(DEV_PID)/$$s.pid"; \
-		[ -f "$$pid_file" ] || return 1; \
-		pid=$$(cat "$$pid_file" 2>/dev/null || true); \
-		case "$$pid" in ''|*[!0-9]*) return 1 ;; esac; \
-		kill -0 "$$pid" 2>/dev/null || return 1; \
-		expected=$$(realpath "./bin/$$s" 2>/dev/null || true); \
-		actual=$$(readlink -f "/proc/$$pid/exe" 2>/dev/null || true); \
-		actual=$${actual% (deleted)}; \
-		[ -n "$$expected" ] && [ "$$actual" = "$$expected" ]; \
+	fail_start() { \
+		log "ERROR: $$*"; \
+		$(MAKE) --no-print-directory _dev-stop-processes; \
+		exit 1; \
 	}; \
-	wait_port() { i=0; while [ $$i -lt 50 ]; do nc -z 127.0.0.1 $$1 >/dev/null 2>&1 && return 0; i=$$((i+1)); sleep 0.2; done; return 1; }; \
-	if service_running hermes; then log "hermes 已在运行，跳过"; else log "启动 hermes (:8081 + gRPC :50051)"; HERMES_SERVER_PORT=8081 ./bin/hermes & echo $$! > "$(DEV_PID)/hermes.pid"; fi; \
-	wait_port 50051 || { log "ERROR: hermes 超时"; exit 1; }; \
-	wait_port 8081 || { log "ERROR: hermes HTTP 超时"; exit 1; }; \
-	if service_running aegis; then log "aegis 已在运行，跳过"; else log "启动 aegis (:18000)"; HERMES_GRPC_ADDR=127.0.0.1:50051 ./bin/aegis & echo $$! > "$(DEV_PID)/aegis.pid"; fi; \
-	wait_port 18000 || { log "ERROR: aegis 超时"; exit 1; }; \
-	if service_running zwei; then log "zwei 已在运行，跳过"; else log "启动 zwei (:18001)"; ZWEI_SERVER_PORT=18001 ./bin/zwei & echo $$! > "$(DEV_PID)/zwei.pid"; fi; \
-	wait_port 18001 || { log "ERROR: zwei 超时"; exit 1; }; \
-	if service_running chaos; then log "chaos 已在运行，跳过"; else log "启动 chaos (:18002)"; CHAOS_SERVER_PORT=18002 ./bin/chaos & echo $$! > "$(DEV_PID)/chaos.pid"; fi; \
-	wait_port 18002 || { log "ERROR: chaos 超时"; exit 1; }; \
+	wait_service() { pid=$$1; port=$$2; i=0; while [ $$i -lt 50 ]; do kill -0 "$$pid" 2>/dev/null || return 1; nc -z 127.0.0.1 "$$port" >/dev/null 2>&1 && return 0; i=$$((i+1)); sleep 0.2; done; return 1; }; \
+	for port in 50051 8081 18000 18001 18002; do \
+		nc -z 127.0.0.1 "$$port" >/dev/null 2>&1 && fail_start "端口 :$$port 已被其他进程占用"; \
+	done; \
+	log "启动 hermes (:8081 + gRPC :50051)"; HERMES_SERVER_PORT=8081 ./bin/hermes & pid=$$!; echo "$$pid" > "$(DEV_PID)/hermes.pid"; \
+	wait_service "$$pid" 50051 || fail_start "hermes gRPC 启动失败"; \
+	wait_service "$$pid" 8081 || fail_start "hermes HTTP 启动失败"; \
+	log "启动 aegis (:18000)"; HERMES_GRPC_ADDR=127.0.0.1:50051 ./bin/aegis & pid=$$!; echo "$$pid" > "$(DEV_PID)/aegis.pid"; \
+	wait_service "$$pid" 18000 || fail_start "aegis 启动失败"; \
+	log "启动 zwei (:18001)"; ZWEI_SERVER_PORT=18001 ./bin/zwei & pid=$$!; echo "$$pid" > "$(DEV_PID)/zwei.pid"; \
+	wait_service "$$pid" 18001 || fail_start "zwei 启动失败"; \
+	log "启动 chaos (:18002)"; CHAOS_SERVER_PORT=18002 ./bin/chaos & pid=$$!; echo "$$pid" > "$(DEV_PID)/chaos.pid"; \
+	wait_service "$$pid" 18002 || fail_start "chaos 启动失败"; \
 	log "全部就绪 (Ctrl+C 停止前台输出, make dev-down 停进程)"; \
 	log "  https://aegis.heliannuuthus.com"; \
 	log "  hermes :8081 + gRPC :50051 | aegis :18000 | zwei :18001 | chaos :18002"; \
@@ -277,28 +274,45 @@ dev-up: dev-check build
 _dev-stop-processes:
 	@log() { echo "[dev] $$*"; }; \
 	for s in chaos zwei aegis hermes; do \
+		expected=$$(realpath -m "./bin/$$s" 2>/dev/null || true); \
+		tracked_pid=""; \
 		pid_file="$(DEV_PID)/$$s.pid"; \
-		[ -f "$$pid_file" ] || continue; \
-		pid=$$(cat "$$pid_file" 2>/dev/null || true); \
-		rm -f "$$pid_file"; \
-		case "$$pid" in ''|*[!0-9]*) log "忽略无效 PID 文件: $$pid_file"; continue ;; esac; \
-		if ! kill -0 "$$pid" 2>/dev/null; then \
-			log "清理已失效的 PID: $$s (pid $$pid)"; \
-			continue; \
+		if [ -f "$$pid_file" ]; then \
+			pid=$$(cat "$$pid_file" 2>/dev/null || true); \
+			rm -f "$$pid_file"; \
+			case "$$pid" in \
+				''|*[!0-9]*) log "忽略无效 PID 文件: $$pid_file" ;; \
+				*) \
+					tracked_pid="$$pid"; \
+					actual=$$(readlink "/proc/$$pid/exe" 2>/dev/null || true); \
+					normalized=$${actual%\ \(deleted\)}; \
+					if [ -n "$$expected" ] && [ "$$normalized" = "$$expected" ]; then \
+						kill "$$pid" 2>/dev/null && log "停止 $$s (pid $$pid)" || true; \
+					elif kill -0 "$$pid" 2>/dev/null; then \
+						log "WARN: PID $$pid 不属于 ./bin/$$s，拒绝停止 ($${actual:-unknown})"; \
+					else \
+						log "清理已失效的 PID: $$s (pid $$pid)"; \
+					fi ;; \
+			esac; \
 		fi; \
-		expected=$$(realpath "./bin/$$s" 2>/dev/null || true); \
-		actual=$$(readlink -f "/proc/$$pid/exe" 2>/dev/null || true); \
-		actual=$${actual% (deleted)}; \
-		if [ -z "$$expected" ] || [ "$$actual" != "$$expected" ]; then \
-			log "WARN: PID $$pid 不属于 ./bin/$$s，拒绝停止 ($${actual:-unknown})"; \
-			continue; \
-		fi; \
-		kill "$$pid" 2>/dev/null && log "停止 $$s (pid $$pid)" || log "WARN: 无法停止 $$s (pid $$pid)"; \
+		for exe_link in /proc/[0-9]*/exe; do \
+			pid=$${exe_link#/proc/}; pid=$${pid%/exe}; \
+			[ "$$pid" = "$$tracked_pid" ] && continue; \
+			actual=$$(readlink "$$exe_link" 2>/dev/null || true); \
+			normalized=$${actual%\ \(deleted\)}; \
+			if [ -n "$$expected" ] && [ "$$normalized" = "$$expected" ]; then \
+				kill "$$pid" 2>/dev/null && log "停止孤儿 $$s (pid $$pid)" || true; \
+			fi; \
+		done; \
 	done
 
 dev-down: _dev-stop-processes
 	@if $(CTR) info >/dev/null 2>&1; then \
 		$(COMPOSE_DEV) down; \
+		for port in 3306 6379 80 443; do \
+			i=0; while [ $$i -lt 50 ] && nc -z 127.0.0.1 "$$port" >/dev/null 2>&1; do i=$$((i+1)); sleep 0.1; done; \
+			if nc -z 127.0.0.1 "$$port" >/dev/null 2>&1; then echo "[dev] ERROR: 容器端口 :$$port 未释放"; exit 1; fi; \
+		done; \
 	else \
 		echo "[dev] $(CTR) daemon 未运行，跳过容器清理"; \
 	fi

--- a/hermes/internal/dto/provision.go
+++ b/hermes/internal/dto/provision.go
@@ -7,6 +7,13 @@ import (
 
 // ==================== Domain ====================
 
+// DomainCreateRequest 创建域请求。
+type DomainCreateRequest struct {
+	DomainID    string  `json:"domain_id" binding:"required"`
+	Name        string  `json:"name" binding:"required"`
+	Description *string `json:"description"`
+}
+
 // DomainUpdateRequest 更新域请求（JSON Merge Patch 语义，仅 name、description 可编辑）
 type DomainUpdateRequest struct {
 	Name        patch.Optional[string] `json:"name"`

--- a/hermes/internal/grpc/key.go
+++ b/hermes/internal/grpc/key.go
@@ -16,10 +16,10 @@ import (
 
 type keyServiceServer struct {
 	hermesv1.UnimplementedKeyServiceServer
-	svc *hermes.Service
+	svc *hermes.KeyService
 }
 
-func NewKeyServiceServer(svc *hermes.Service) hermesv1.KeyServiceServer {
+func NewKeyServiceServer(svc *hermes.KeyService) hermesv1.KeyServiceServer {
 	return &keyServiceServer{svc: svc}
 }
 

--- a/hermes/internal/grpc/provision.go
+++ b/hermes/internal/grpc/provision.go
@@ -17,10 +17,10 @@ import (
 
 type provisionServiceServer struct {
 	hermesv1.UnimplementedProvisionServiceServer
-	svc *hermes.Service
+	svc *hermes.ProvisionService
 }
 
-func NewProvisionServiceServer(svc *hermes.Service) hermesv1.ProvisionServiceServer {
+func NewProvisionServiceServer(svc *hermes.ProvisionService) hermesv1.ProvisionServiceServer {
 	return &provisionServiceServer{svc: svc}
 }
 

--- a/hermes/internal/grpc/resource.go
+++ b/hermes/internal/grpc/resource.go
@@ -17,10 +17,10 @@ import (
 
 type resourceServiceServer struct {
 	hermesv1.UnimplementedResourceServiceServer
-	svc *hermes.Service
+	svc *hermes.ResourceService
 }
 
-func NewResourceServiceServer(svc *hermes.Service) hermesv1.ResourceServiceServer {
+func NewResourceServiceServer(svc *hermes.ResourceService) hermesv1.ResourceServiceServer {
 	return &resourceServiceServer{svc: svc}
 }
 

--- a/hermes/internal/grpc/user.go
+++ b/hermes/internal/grpc/user.go
@@ -16,10 +16,10 @@ import (
 
 type userServiceServer struct {
 	hermesv1.UnimplementedUserServiceServer
-	svc *hermes.Service
+	svc *hermes.UserService
 }
 
-func NewUserServiceServer(svc *hermes.Service) hermesv1.UserServiceServer {
+func NewUserServiceServer(svc *hermes.UserService) hermesv1.UserServiceServer {
 	return &userServiceServer{svc: svc}
 }
 

--- a/hermes/internal/handler.go
+++ b/hermes/internal/handler.go
@@ -13,12 +13,20 @@ import (
 
 // Handler 管理服务处理器
 type Handler struct {
-	service *Service
+	provision *ProvisionService
+	resource  *ResourceService
+	key       *KeyService
+	user      *UserService
 }
 
 // NewHandler 创建管理服务处理器
-func NewHandler(service *Service) *Handler {
-	return &Handler{service: service}
+func NewHandler(services *Services) *Handler {
+	return &Handler{
+		provision: services.Provision,
+		resource:  services.Resource,
+		key:       services.Key,
+		user:      services.User,
+	}
 }
 
 // ==================== Domain 相关 ====================
@@ -26,7 +34,7 @@ func NewHandler(service *Service) *Handler {
 // GetDomain GET /hermes/domains/:domain_id
 func (h *Handler) GetDomain(c *gin.Context) {
 	domainID := c.Param("domain_id")
-	domain, err := h.service.GetDomain(c.Request.Context(), domainID)
+	domain, err := h.provision.GetDomain(c.Request.Context(), domainID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -43,7 +51,7 @@ func (h *Handler) GetDomain(c *gin.Context) {
 
 // ListIDPKeys GET /hermes/idp-keys
 func (h *Handler) ListIDPKeys(c *gin.Context) {
-	secrets, err := h.service.GetIDPKeys(c.Request.Context())
+	secrets, err := h.key.GetIDPKeys(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -59,7 +67,7 @@ func (h *Handler) ListIDPKeys(c *gin.Context) {
 func (h *Handler) GetIDPKey(c *gin.Context) {
 	idpType := c.Param("idp_type")
 	tAppID := c.Param("t_app_id")
-	secret, err := h.service.GetIDPKey(c.Request.Context(), idpType, tAppID)
+	secret, err := h.key.GetIDPKey(c.Request.Context(), idpType, tAppID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -74,7 +82,7 @@ func (h *Handler) CreateIDPKey(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	secret, err := h.service.CreateIDPKey(c.Request.Context(), &req)
+	secret, err := h.key.CreateIDPKey(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -91,7 +99,7 @@ func (h *Handler) UpdateIDPKey(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateIDPKey(c.Request.Context(), idpType, tAppID, &req); err != nil {
+	if err := h.key.UpdateIDPKey(c.Request.Context(), idpType, tAppID, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -102,7 +110,7 @@ func (h *Handler) UpdateIDPKey(c *gin.Context) {
 func (h *Handler) DeleteIDPKey(c *gin.Context) {
 	idpType := c.Param("idp_type")
 	tAppID := c.Param("t_app_id")
-	if err := h.service.DeleteIDPKey(c.Request.Context(), idpType, tAppID); err != nil {
+	if err := h.key.DeleteIDPKey(c.Request.Context(), idpType, tAppID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -114,7 +122,7 @@ func (h *Handler) DeleteIDPKey(c *gin.Context) {
 // ListDomainIDPConfigs GET /hermes/domains/:domain_id/idp-configs
 func (h *Handler) ListDomainIDPConfigs(c *gin.Context) {
 	domainID := c.Param("domain_id")
-	configs, err := h.service.ListDomainIDPConfigs(c.Request.Context(), domainID)
+	configs, err := h.provision.ListDomainIDPConfigs(c.Request.Context(), domainID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -130,7 +138,7 @@ func (h *Handler) ListDomainIDPConfigs(c *gin.Context) {
 func (h *Handler) GetDomainIDPConfig(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	idpType := c.Param("idp_type")
-	cfg, err := h.service.GetDomainIDPConfig(c.Request.Context(), domainID, idpType)
+	cfg, err := h.provision.GetDomainIDPConfig(c.Request.Context(), domainID, idpType)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -146,7 +154,7 @@ func (h *Handler) CreateDomainIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	cfg, err := h.service.CreateDomainIDPConfig(c.Request.Context(), domainID, &req)
+	cfg, err := h.provision.CreateDomainIDPConfig(c.Request.Context(), domainID, &req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -163,7 +171,7 @@ func (h *Handler) UpdateDomainIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateDomainIDPConfig(c.Request.Context(), domainID, idpType, &req); err != nil {
+	if err := h.provision.UpdateDomainIDPConfig(c.Request.Context(), domainID, idpType, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -174,7 +182,7 @@ func (h *Handler) UpdateDomainIDPConfig(c *gin.Context) {
 func (h *Handler) DeleteDomainIDPConfig(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	idpType := c.Param("idp_type")
-	if err := h.service.DeleteDomainIDPConfig(c.Request.Context(), domainID, idpType); err != nil {
+	if err := h.provision.DeleteDomainIDPConfig(c.Request.Context(), domainID, idpType); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -189,7 +197,7 @@ func (h *Handler) UpdateDomain(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	domain, err := h.service.UpdateDomain(c.Request.Context(), domainID, &req)
+	domain, err := h.provision.UpdateDomain(c.Request.Context(), domainID, &req)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -203,7 +211,7 @@ func (h *Handler) UpdateDomain(c *gin.Context) {
 
 // ListDomains GET /hermes/domains
 func (h *Handler) ListDomains(c *gin.Context) {
-	domains, err := h.service.ListDomains(c.Request.Context())
+	domains, err := h.provision.ListDomains(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -230,7 +238,7 @@ func (h *Handler) ListServices(c *gin.Context) {
 		return
 	}
 
-	page, err := h.service.ListServices(c.Request.Context(), domainID, &req)
+	page, err := h.provision.ListServices(c.Request.Context(), domainID, &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -245,7 +253,7 @@ func (h *Handler) ListServices(c *gin.Context) {
 func (h *Handler) GetService(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -266,7 +274,7 @@ func (h *Handler) CreateService(c *gin.Context) {
 		return
 	}
 	req.DomainID = domainID
-	service, err := h.service.CreateService(c.Request.Context(), &req)
+	service, err := h.provision.CreateService(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -278,7 +286,7 @@ func (h *Handler) CreateService(c *gin.Context) {
 func (h *Handler) UpdateService(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -292,7 +300,7 @@ func (h *Handler) UpdateService(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateService(c.Request.Context(), serviceID, &req); err != nil {
+	if err := h.provision.UpdateService(c.Request.Context(), serviceID, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -303,7 +311,7 @@ func (h *Handler) UpdateService(c *gin.Context) {
 func (h *Handler) DeleteService(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -312,7 +320,7 @@ func (h *Handler) DeleteService(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "service not found in this domain"})
 		return
 	}
-	if err := h.service.DeleteService(c.Request.Context(), serviceID); err != nil {
+	if err := h.provision.DeleteService(c.Request.Context(), serviceID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -323,7 +331,7 @@ func (h *Handler) DeleteService(c *gin.Context) {
 func (h *Handler) GetServiceApplicationRelations(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -332,7 +340,7 @@ func (h *Handler) GetServiceApplicationRelations(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "service not found in this domain"})
 		return
 	}
-	relations, err := h.service.GetServiceApplicationRelations(c.Request.Context(), serviceID)
+	relations, err := h.resource.GetServiceApplicationRelations(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -354,7 +362,7 @@ func (h *Handler) GetServiceAppRelations(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
 	appID := c.Param("app_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -363,7 +371,7 @@ func (h *Handler) GetServiceAppRelations(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "service not found in this domain"})
 		return
 	}
-	rels, err := h.service.GetServiceAppRelations(c.Request.Context(), serviceID, appID)
+	rels, err := h.resource.GetServiceAppRelations(c.Request.Context(), serviceID, appID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -376,7 +384,7 @@ func (h *Handler) SetServiceAppRelations(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	serviceID := c.Param("service_id")
 	appID := c.Param("app_id")
-	service, err := h.service.GetService(c.Request.Context(), serviceID)
+	service, err := h.provision.GetService(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -390,7 +398,7 @@ func (h *Handler) SetServiceAppRelations(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.SetApplicationServiceRelations(c.Request.Context(), &dto.ApplicationServiceRelationRequest{
+	if err := h.resource.SetApplicationServiceRelations(c.Request.Context(), &dto.ApplicationServiceRelationRequest{
 		AppID: appID, ServiceID: serviceID, Relations: req.Relations,
 	}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -410,7 +418,7 @@ func (h *Handler) ListApplications(c *gin.Context) {
 		return
 	}
 
-	page, err := h.service.ListApplications(c.Request.Context(), domainID, &req)
+	page, err := h.provision.ListApplications(c.Request.Context(), domainID, &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -425,7 +433,7 @@ func (h *Handler) ListApplications(c *gin.Context) {
 func (h *Handler) GetApplication(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -446,7 +454,7 @@ func (h *Handler) CreateApplication(c *gin.Context) {
 		return
 	}
 	req.DomainID = domainID
-	app, err := h.service.CreateApplication(c.Request.Context(), &req)
+	app, err := h.provision.CreateApplication(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -458,7 +466,7 @@ func (h *Handler) CreateApplication(c *gin.Context) {
 func (h *Handler) UpdateApplication(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -472,7 +480,7 @@ func (h *Handler) UpdateApplication(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateApplication(c.Request.Context(), appID, &req); err != nil {
+	if err := h.provision.UpdateApplication(c.Request.Context(), appID, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -483,7 +491,7 @@ func (h *Handler) UpdateApplication(c *gin.Context) {
 func (h *Handler) ListApplicationIDPConfigs(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -492,7 +500,7 @@ func (h *Handler) ListApplicationIDPConfigs(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "application not found in this domain"})
 		return
 	}
-	configs, err := h.service.ListApplicationIDPConfigs(c.Request.Context(), appID)
+	configs, err := h.provision.ListApplicationIDPConfigs(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -516,7 +524,7 @@ func (h *Handler) ListApplicationIDPConfigs(c *gin.Context) {
 func (h *Handler) CreateApplicationIDPConfig(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -530,7 +538,7 @@ func (h *Handler) CreateApplicationIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	cfg, err := h.service.CreateApplicationIDPConfig(c.Request.Context(), appID, &req)
+	cfg, err := h.provision.CreateApplicationIDPConfig(c.Request.Context(), appID, &req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -551,7 +559,7 @@ func (h *Handler) UpdateApplicationIDPConfig(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
 	idpType := c.Param("idp_type")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -565,7 +573,7 @@ func (h *Handler) UpdateApplicationIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateApplicationIDPConfig(c.Request.Context(), appID, idpType, &req); err != nil {
+	if err := h.provision.UpdateApplicationIDPConfig(c.Request.Context(), appID, idpType, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -577,7 +585,7 @@ func (h *Handler) DeleteApplicationIDPConfig(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
 	idpType := c.Param("idp_type")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -586,7 +594,7 @@ func (h *Handler) DeleteApplicationIDPConfig(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "application not found in this domain"})
 		return
 	}
-	if err := h.service.DeleteApplicationIDPConfig(c.Request.Context(), appID, idpType); err != nil {
+	if err := h.provision.DeleteApplicationIDPConfig(c.Request.Context(), appID, idpType); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -597,7 +605,7 @@ func (h *Handler) DeleteApplicationIDPConfig(c *gin.Context) {
 func (h *Handler) ListApplicationServiceRelations(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -606,7 +614,7 @@ func (h *Handler) ListApplicationServiceRelations(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "application not found in this domain"})
 		return
 	}
-	relations, err := h.service.ListApplicationServiceRelations(c.Request.Context(), appID)
+	relations, err := h.resource.ListApplicationServiceRelations(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -626,7 +634,7 @@ func (h *Handler) ListApplicationServiceRelations(c *gin.Context) {
 // DeleteDomain DELETE /hermes/domains/:domain_id
 func (h *Handler) DeleteDomain(c *gin.Context) {
 	domainID := c.Param("domain_id")
-	if err := h.service.DeleteDomain(c.Request.Context(), domainID); err != nil {
+	if err := h.provision.DeleteDomain(c.Request.Context(), domainID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -637,7 +645,7 @@ func (h *Handler) DeleteDomain(c *gin.Context) {
 func (h *Handler) DeleteApplication(c *gin.Context) {
 	domainID := c.Param("domain_id")
 	appID := c.Param("app_id")
-	app, err := h.service.GetApplication(c.Request.Context(), appID)
+	app, err := h.provision.GetApplication(c.Request.Context(), appID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -646,7 +654,7 @@ func (h *Handler) DeleteApplication(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "application not found in this domain"})
 		return
 	}
-	if err := h.service.DeleteApplication(c.Request.Context(), appID); err != nil {
+	if err := h.provision.DeleteApplication(c.Request.Context(), appID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -656,7 +664,7 @@ func (h *Handler) DeleteApplication(c *gin.Context) {
 // DeleteGroup DELETE /hermes/groups/:group_id
 func (h *Handler) DeleteGroup(c *gin.Context) {
 	groupID := c.Param("group_id")
-	if err := h.service.DeleteGroup(c.Request.Context(), groupID); err != nil {
+	if err := h.user.DeleteGroup(c.Request.Context(), groupID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -668,7 +676,7 @@ func (h *Handler) DeleteGroup(c *gin.Context) {
 // ListServiceChallengeSettings GET /hermes/domains/:domain_id/services/:service_id/challenge-settings
 func (h *Handler) ListServiceChallengeSettings(c *gin.Context) {
 	serviceID := c.Param("service_id")
-	settings, err := h.service.ListServiceChallengeSettings(c.Request.Context(), serviceID)
+	settings, err := h.provision.ListServiceChallengeSettings(c.Request.Context(), serviceID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -688,7 +696,7 @@ func (h *Handler) CreateServiceChallengeSetting(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	setting, err := h.service.CreateServiceChallengeSetting(c.Request.Context(), serviceID, &req)
+	setting, err := h.provision.CreateServiceChallengeSetting(c.Request.Context(), serviceID, &req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -705,7 +713,7 @@ func (h *Handler) UpdateServiceChallengeSetting(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.UpdateServiceChallengeSetting(c.Request.Context(), serviceID, challengeType, &req); err != nil {
+	if err := h.provision.UpdateServiceChallengeSetting(c.Request.Context(), serviceID, challengeType, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -716,7 +724,7 @@ func (h *Handler) UpdateServiceChallengeSetting(c *gin.Context) {
 func (h *Handler) DeleteServiceChallengeSetting(c *gin.Context) {
 	serviceID := c.Param("service_id")
 	challengeType := c.Param("type")
-	if err := h.service.DeleteServiceChallengeSetting(c.Request.Context(), serviceID, challengeType); err != nil {
+	if err := h.provision.DeleteServiceChallengeSetting(c.Request.Context(), serviceID, challengeType); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -733,7 +741,7 @@ func (h *Handler) CreateRelationship(c *gin.Context) {
 		return
 	}
 
-	rel, err := h.service.CreateRelationship(c.Request.Context(), &req)
+	rel, err := h.resource.CreateRelationship(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -750,7 +758,7 @@ func (h *Handler) DeleteRelationship(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.DeleteRelationship(c.Request.Context(), &req); err != nil {
+	if err := h.resource.DeleteRelationship(c.Request.Context(), &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -766,7 +774,7 @@ func (h *Handler) ListRelationships(c *gin.Context) {
 		return
 	}
 
-	page, err := h.service.ListRelationships(c.Request.Context(), &req)
+	page, err := h.resource.ListRelationships(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -785,7 +793,7 @@ func (h *Handler) UpdateRelationship(c *gin.Context) {
 		return
 	}
 
-	rel, err := h.service.UpdateRelationship(c.Request.Context(), &req)
+	rel, err := h.resource.UpdateRelationship(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -807,7 +815,7 @@ func (h *Handler) ListAppServiceRelationships(c *gin.Context) {
 		return
 	}
 
-	page, err := h.service.ListAppServiceRelationships(c.Request.Context(), appID, serviceID, &req)
+	page, err := h.resource.ListAppServiceRelationships(c.Request.Context(), appID, serviceID, &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -829,7 +837,7 @@ func (h *Handler) CreateAppServiceRelationship(c *gin.Context) {
 		return
 	}
 
-	rel, err := h.service.CreateAppServiceRelationship(c.Request.Context(), appID, serviceID, &req)
+	rel, err := h.resource.CreateAppServiceRelationship(c.Request.Context(), appID, serviceID, &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -856,7 +864,7 @@ func (h *Handler) UpdateAppServiceRelationship(c *gin.Context) {
 		return
 	}
 
-	rel, err := h.service.UpdateAppServiceRelationship(c.Request.Context(), appID, serviceID, uint(relationshipID), &req)
+	rel, err := h.resource.UpdateAppServiceRelationship(c.Request.Context(), appID, serviceID, uint(relationshipID), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -877,7 +885,7 @@ func (h *Handler) DeleteAppServiceRelationship(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.DeleteAppServiceRelationship(c.Request.Context(), appID, serviceID, uint(relationshipID)); err != nil {
+	if err := h.resource.DeleteAppServiceRelationship(c.Request.Context(), appID, serviceID, uint(relationshipID)); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -895,7 +903,7 @@ func (h *Handler) CreateGroup(c *gin.Context) {
 		return
 	}
 
-	group, err := h.service.CreateGroup(c.Request.Context(), &req)
+	group, err := h.user.CreateGroup(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -907,7 +915,7 @@ func (h *Handler) CreateGroup(c *gin.Context) {
 // GetGroup GET /hermes/groups/:group_id
 func (h *Handler) GetGroup(c *gin.Context) {
 	groupID := c.Param("group_id")
-	group, err := h.service.GetGroup(c.Request.Context(), groupID)
+	group, err := h.user.GetGroup(c.Request.Context(), groupID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
@@ -924,7 +932,7 @@ func (h *Handler) ListGroups(c *gin.Context) {
 		return
 	}
 
-	page, err := h.service.ListGroups(c.Request.Context(), &req)
+	page, err := h.user.ListGroups(c.Request.Context(), &req)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -944,7 +952,7 @@ func (h *Handler) UpdateGroup(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.UpdateGroup(c.Request.Context(), groupID, &req); err != nil {
+	if err := h.user.UpdateGroup(c.Request.Context(), groupID, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -962,7 +970,7 @@ func (h *Handler) SetGroupMembers(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.SetGroupMembers(c.Request.Context(), &req); err != nil {
+	if err := h.user.SetGroupMembers(c.Request.Context(), &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -973,7 +981,7 @@ func (h *Handler) SetGroupMembers(c *gin.Context) {
 // GetGroupMembers GET /hermes/groups/:group_id/members
 func (h *Handler) GetGroupMembers(c *gin.Context) {
 	groupID := c.Param("group_id")
-	members, err := h.service.GetGroupMembers(c.Request.Context(), groupID)
+	members, err := h.user.GetGroupMembers(c.Request.Context(), groupID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/hermes/internal/handler.go
+++ b/hermes/internal/handler.go
@@ -1,13 +1,16 @@
 package hermes
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
 	"github.com/heliannuuthus/hermes/internal/dto"
 	"github.com/heliannuuthus/hermes/internal/models"
+	"github.com/heliannuuthus/pkg/logger"
 	"github.com/heliannuuthus/pkg/pagination"
 )
 
@@ -30,6 +33,34 @@ func NewHandler(services *Services) *Handler {
 }
 
 // ==================== Domain 相关 ====================
+
+// CreateDomain POST /hermes/domains
+func (h *Handler) CreateDomain(c *gin.Context) {
+	var req dto.DomainCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	domain, err := h.provision.CreateDomain(c.Request.Context(), &req)
+	if err != nil {
+		if errors.Is(err, ErrDomainAlreadyExists) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			return
+		}
+		if errors.Is(err, ErrInvalidDomain) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		logger.Errorf("创建域失败: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建域失败"})
+		return
+	}
+	c.JSON(http.StatusCreated, dto.DomainResponse{
+		DomainID:    domain.DomainID,
+		Name:        domain.Name,
+		Description: domain.Description,
+	})
+}
 
 // GetDomain GET /hermes/domains/:domain_id
 func (h *Handler) GetDomain(c *gin.Context) {
@@ -199,7 +230,16 @@ func (h *Handler) UpdateDomain(c *gin.Context) {
 	}
 	domain, err := h.provision.UpdateDomain(c.Request.Context(), domainID, &req)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		if errors.Is(err, ErrInvalidDomain) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "域不存在"})
+			return
+		}
+		logger.Errorf("更新域失败: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "更新域失败"})
 		return
 	}
 	c.JSON(http.StatusOK, dto.DomainResponse{

--- a/hermes/internal/key.go
+++ b/hermes/internal/key.go
@@ -36,7 +36,7 @@ func generateEncryptedKey(aad string) (string, error) {
 }
 
 // GetDomainKeys 获取域的所有有效密钥（已解密），回退到配置文件兼容旧部署
-func (s *Service) GetDomainKeys(ctx context.Context, domainID string) ([][]byte, error) {
+func (s *KeyService) GetDomainKeys(ctx context.Context, domainID string) ([][]byte, error) {
 	keys, err := s.getKeys(ctx, models.KeyOwnerDomain, domainID)
 	if err != nil {
 		return nil, fmt.Errorf("获取域密钥失败: %w", err)
@@ -51,17 +51,17 @@ func (s *Service) GetDomainKeys(ctx context.Context, domainID string) ([][]byte,
 }
 
 // GetApplicationKeys 获取应用的所有有效密钥（已解密）
-func (s *Service) GetApplicationKeys(ctx context.Context, appID string) ([][]byte, error) {
+func (s *KeyService) GetApplicationKeys(ctx context.Context, appID string) ([][]byte, error) {
 	return s.getKeys(ctx, models.KeyOwnerApplication, appID)
 }
 
 // GetServiceKeys 获取服务的所有有效密钥（已解密）
-func (s *Service) GetServiceKeys(ctx context.Context, serviceID string) ([][]byte, error) {
+func (s *KeyService) GetServiceKeys(ctx context.Context, serviceID string) ([][]byte, error) {
 	return s.getKeys(ctx, models.KeyOwnerService, serviceID)
 }
 
 // RotateKey 轮换密钥：给旧主密钥设 expired_at，插入新密钥
-func (s *Service) RotateKey(ctx context.Context, ownerType, ownerID string, window time.Duration) error {
+func (s *KeyService) RotateKey(ctx context.Context, ownerType, ownerID string, window time.Duration) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		expiredAt := time.Now().Add(window)
 		if err := tx.Model(&models.Key{}).
@@ -74,7 +74,7 @@ func (s *Service) RotateKey(ctx context.Context, ownerType, ownerID string, wind
 }
 
 // getKeys 获取指定 owner 的所有有效密钥（已解密），按 created_at DESC 排序
-func (s *Service) getKeys(ctx context.Context, ownerType, ownerID string) ([][]byte, error) {
+func (s *KeyService) getKeys(ctx context.Context, ownerType, ownerID string) ([][]byte, error) {
 	var keys []models.Key
 	if err := s.db.WithContext(ctx).
 		Where("owner_type = ? AND owner_id = ? AND (expired_at IS NULL OR expired_at > NOW())", ownerType, ownerID).
@@ -108,7 +108,7 @@ func (s *Service) getKeys(ctx context.Context, ownerType, ownerID string) ([][]b
 	return result, nil
 }
 
-func (s *Service) encryptIDPKey(plaintext, aad string) (string, error) {
+func (s *KeyService) encryptIDPKey(plaintext, aad string) (string, error) {
 	dbEncKey, err := config.GetDBEncKeyRaw()
 	if err != nil {
 		return "", fmt.Errorf("获取数据库加密密钥失败: %w", err)
@@ -120,7 +120,7 @@ func (s *Service) encryptIDPKey(plaintext, aad string) (string, error) {
 	return base64.StdEncoding.EncodeToString(encrypted), nil
 }
 
-func (s *Service) decryptIDPKey(cipherBase64, aad string) (string, error) {
+func (s *KeyService) decryptIDPKey(cipherBase64, aad string) (string, error) {
 	dbEncKey, err := config.GetDBEncKeyRaw()
 	if err != nil {
 		return "", fmt.Errorf("获取数据库加密密钥失败: %w", err)
@@ -137,7 +137,7 @@ func (s *Service) decryptIDPKey(cipherBase64, aad string) (string, error) {
 }
 
 // CreateKey 为 owner 创建新密钥（在事务中调用）
-func (s *Service) CreateKey(tx *gorm.DB, ownerType, ownerID string) error {
+func (s *KeyService) CreateKey(tx *gorm.DB, ownerType, ownerID string) error {
 	encryptedKey, err := generateEncryptedKey(ownerID)
 	if err != nil {
 		return err
@@ -156,7 +156,7 @@ func (s *Service) CreateKey(tx *gorm.DB, ownerType, ownerID string) error {
 // ==================== IDP Key 相关 ====================
 
 // GetIDPKeys 获取所有 IDP 密钥
-func (s *Service) GetIDPKeys(ctx context.Context) ([]*models.IDPKey, error) {
+func (s *KeyService) GetIDPKeys(ctx context.Context) ([]*models.IDPKey, error) {
 	var secrets []*models.IDPKey
 	if err := s.db.WithContext(ctx).Find(&secrets).Error; err != nil {
 		return nil, fmt.Errorf("获取 IDP 密钥列表失败: %w", err)
@@ -165,7 +165,7 @@ func (s *Service) GetIDPKeys(ctx context.Context) ([]*models.IDPKey, error) {
 }
 
 // GetIDPKey 获取指定 IDP 密钥
-func (s *Service) GetIDPKey(ctx context.Context, idpType, tAppID string) (*models.IDPKey, error) {
+func (s *KeyService) GetIDPKey(ctx context.Context, idpType, tAppID string) (*models.IDPKey, error) {
 	var secret models.IDPKey
 	if err := s.db.WithContext(ctx).
 		Where("idp_type = ? AND t_app_id = ?", idpType, tAppID).
@@ -176,7 +176,7 @@ func (s *Service) GetIDPKey(ctx context.Context, idpType, tAppID string) (*model
 }
 
 // CreateIDPKey 创建 IDP 密钥
-func (s *Service) CreateIDPKey(ctx context.Context, req *dto.IDPKeyCreateRequest) (*models.IDPKey, error) {
+func (s *KeyService) CreateIDPKey(ctx context.Context, req *dto.IDPKeyCreateRequest) (*models.IDPKey, error) {
 	aad := req.IDPType + ":" + req.TAppID
 	encryptedSecret, err := s.encryptIDPKey(req.TSecret, aad)
 	if err != nil {
@@ -194,7 +194,7 @@ func (s *Service) CreateIDPKey(ctx context.Context, req *dto.IDPKeyCreateRequest
 }
 
 // UpdateIDPKey 更新 IDP 密钥
-func (s *Service) UpdateIDPKey(ctx context.Context, idpType, tAppID string, req *dto.IDPKeyUpdateRequest) error {
+func (s *KeyService) UpdateIDPKey(ctx context.Context, idpType, tAppID string, req *dto.IDPKeyUpdateRequest) error {
 	if !req.TSecret.IsPresent() || req.TSecret.IsNull() {
 		return nil
 	}
@@ -216,7 +216,7 @@ func (s *Service) UpdateIDPKey(ctx context.Context, idpType, tAppID string, req 
 }
 
 // DeleteIDPKey 删除 IDP 密钥
-func (s *Service) DeleteIDPKey(ctx context.Context, idpType, tAppID string) error {
+func (s *KeyService) DeleteIDPKey(ctx context.Context, idpType, tAppID string) error {
 	result := s.db.WithContext(ctx).
 		Where("idp_type = ? AND t_app_id = ?", idpType, tAppID).
 		Delete(&models.IDPKey{})
@@ -230,7 +230,7 @@ func (s *Service) DeleteIDPKey(ctx context.Context, idpType, tAppID string) erro
 }
 
 // ResolveIDPKey 解析应用的有效 IDP 密钥
-func (s *Service) ResolveIDPKey(ctx context.Context, appID, idpType string) (tAppID, tSecret string, err error) {
+func (s *KeyService) ResolveIDPKey(ctx context.Context, appID, idpType string) (tAppID, tSecret string, err error) {
 	var appCfg models.ApplicationIDPConfig
 	if findErr := s.db.WithContext(ctx).
 		Where("app_id = ? AND `type` = ?", appID, idpType).

--- a/hermes/internal/provision.go
+++ b/hermes/internal/provision.go
@@ -20,7 +20,7 @@ import (
 // ==================== Domain 相关 ====================
 
 // GetDomain 获取域基础信息（仅 t_domain 元数据）
-func (s *Service) GetDomain(ctx context.Context, domainID string) (*models.Domain, error) {
+func (s *ProvisionService) GetDomain(ctx context.Context, domainID string) (*models.Domain, error) {
 	rec, err := s.getDomain(ctx, domainID)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (s *Service) GetDomain(ctx context.Context, domainID string) (*models.Domai
 }
 
 // ListDomains 列出所有域（仅基础信息）
-func (s *Service) ListDomains(ctx context.Context) ([]models.Domain, error) {
+func (s *ProvisionService) ListDomains(ctx context.Context) ([]models.Domain, error) {
 	var recs []models.DomainRecord
 	if err := s.db.WithContext(ctx).Find(&recs).Error; err != nil {
 		return nil, fmt.Errorf("列出域失败: %w", err)
@@ -50,7 +50,7 @@ func (s *Service) ListDomains(ctx context.Context) ([]models.Domain, error) {
 }
 
 // UpdateDomain 更新域（仅 name、description）
-func (s *Service) UpdateDomain(ctx context.Context, domainID string, req *dto.DomainUpdateRequest) (*models.Domain, error) {
+func (s *ProvisionService) UpdateDomain(ctx context.Context, domainID string, req *dto.DomainUpdateRequest) (*models.Domain, error) {
 	if _, err := s.getDomain(ctx, domainID); err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (s *Service) UpdateDomain(ctx context.Context, domainID string, req *dto.Do
 }
 
 // DeleteDomain 删除域（级联删除关联数据）
-func (s *Service) DeleteDomain(ctx context.Context, domainID string) error {
+func (s *ProvisionService) DeleteDomain(ctx context.Context, domainID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var rec models.DomainRecord
 		if err := tx.Where("domain_id = ?", domainID).First(&rec).Error; err != nil {
@@ -93,7 +93,7 @@ func (s *Service) DeleteDomain(ctx context.Context, domainID string) error {
 // ==================== Service 相关 ====================
 
 // CreateService 创建服务
-func (s *Service) CreateService(ctx context.Context, req *dto.ServiceCreateRequest) (*models.Service, error) {
+func (s *ProvisionService) CreateService(ctx context.Context, req *dto.ServiceCreateRequest) (*models.Service, error) {
 	if err := validation.ValidateID("domain_id", req.DomainID); err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (s *Service) CreateService(ctx context.Context, req *dto.ServiceCreateReque
 		if err := tx.Create(svc).Error; err != nil {
 			return fmt.Errorf("创建服务失败: %w", err)
 		}
-		return s.CreateKey(tx, models.KeyOwnerService, req.ServiceID)
+		return s.keySvc.CreateKey(tx, models.KeyOwnerService, req.ServiceID)
 	})
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func (s *Service) CreateService(ctx context.Context, req *dto.ServiceCreateReque
 }
 
 // GetService 获取服务（不含密钥）
-func (s *Service) GetService(ctx context.Context, serviceID string) (*models.Service, error) {
+func (s *ProvisionService) GetService(ctx context.Context, serviceID string) (*models.Service, error) {
 	var svc models.Service
 	if err := s.db.WithContext(ctx).Where("service_id = ?", serviceID).First(&svc).Error; err != nil {
 		return nil, fmt.Errorf("获取服务失败: %w", err)
@@ -140,7 +140,7 @@ var serviceFilters = filter.Whitelist{
 }
 
 // ListServices 列出服务（游标分页）
-func (s *Service) ListServices(ctx context.Context, domainID string, req *dto.ListRequest) (*pagination.Items[models.Service], error) {
+func (s *ProvisionService) ListServices(ctx context.Context, domainID string, req *dto.ListRequest) (*pagination.Items[models.Service], error) {
 	query := s.db.WithContext(ctx).Model(&models.Service{})
 	if domainID != "" {
 		query = query.Where("domain_id IN (?, ?)", domainID, models.InheritedDomainID)
@@ -150,7 +150,7 @@ func (s *Service) ListServices(ctx context.Context, domainID string, req *dto.Li
 }
 
 // UpdateService 更新服务（JSON Merge Patch 语义）
-func (s *Service) UpdateService(ctx context.Context, serviceID string, req *dto.ServiceUpdateRequest) error {
+func (s *ProvisionService) UpdateService(ctx context.Context, serviceID string, req *dto.ServiceUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("name", req.Name),
 		patch.Field("description", req.Description),
@@ -168,7 +168,7 @@ func (s *Service) UpdateService(ctx context.Context, serviceID string, req *dto.
 }
 
 // DeleteService 删除服务（级联删除关联数据）
-func (s *Service) DeleteService(ctx context.Context, serviceID string) error {
+func (s *ProvisionService) DeleteService(ctx context.Context, serviceID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var svc models.Service
 		if err := tx.Where("service_id = ?", serviceID).First(&svc).Error; err != nil {
@@ -208,7 +208,7 @@ func marshalOptionalStringSlice(s []string) *string {
 }
 
 // CreateApplication 创建应用
-func (s *Service) CreateApplication(ctx context.Context, req *dto.ApplicationCreateRequest) (*models.Application, error) {
+func (s *ProvisionService) CreateApplication(ctx context.Context, req *dto.ApplicationCreateRequest) (*models.Application, error) {
 	if err := validation.ValidateID("domain_id", req.DomainID); err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (s *Service) CreateApplication(ctx context.Context, req *dto.ApplicationCre
 			return fmt.Errorf("创建应用失败: %w", err)
 		}
 		if req.NeedKey {
-			if err := s.CreateKey(tx, models.KeyOwnerApplication, appID); err != nil {
+			if err := s.keySvc.CreateKey(tx, models.KeyOwnerApplication, appID); err != nil {
 				return err
 			}
 		}
@@ -274,7 +274,7 @@ func (s *Service) CreateApplication(ctx context.Context, req *dto.ApplicationCre
 }
 
 // GetApplication 获取应用（不含密钥）
-func (s *Service) GetApplication(ctx context.Context, appID string) (*models.Application, error) {
+func (s *ProvisionService) GetApplication(ctx context.Context, appID string) (*models.Application, error) {
 	var app models.Application
 	if err := s.db.WithContext(ctx).Where("app_id = ?", appID).First(&app).Error; err != nil {
 		return nil, fmt.Errorf("获取应用失败: %w", err)
@@ -287,7 +287,7 @@ var applicationFilters = filter.Whitelist{
 }
 
 // ListApplications 列出应用（游标分页）
-func (s *Service) ListApplications(ctx context.Context, domainID string, req *dto.ListRequest) (*pagination.Items[models.Application], error) {
+func (s *ProvisionService) ListApplications(ctx context.Context, domainID string, req *dto.ListRequest) (*pagination.Items[models.Application], error) {
 	query := s.db.WithContext(ctx).Model(&models.Application{})
 	if domainID != "" {
 		query = query.Where("domain_id = ?", domainID)
@@ -323,7 +323,7 @@ func applyOptionalURIList(
 }
 
 // UpdateApplication 更新应用（JSON Merge Patch 语义）
-func (s *Service) UpdateApplication(ctx context.Context, appID string, req *dto.ApplicationUpdateRequest) error {
+func (s *ProvisionService) UpdateApplication(ctx context.Context, appID string, req *dto.ApplicationUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("name", req.Name),
 		patch.Field("description", req.Description),
@@ -354,7 +354,7 @@ func (s *Service) UpdateApplication(ctx context.Context, appID string, req *dto.
 }
 
 // DeleteApplication 删除应用（级联删除关联数据）
-func (s *Service) DeleteApplication(ctx context.Context, appID string) error {
+func (s *ProvisionService) DeleteApplication(ctx context.Context, appID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var app models.Application
 		if err := tx.Where("app_id = ?", appID).First(&app).Error; err != nil {
@@ -376,7 +376,7 @@ func (s *Service) DeleteApplication(ctx context.Context, appID string) error {
 // ==================== Domain IDP Config 相关 ====================
 
 // ListDomainIDPConfigs 获取域下所有 IDP 配置（按 priority 降序）
-func (s *Service) ListDomainIDPConfigs(ctx context.Context, domainID string) ([]*models.DomainIDPConfig, error) {
+func (s *ProvisionService) ListDomainIDPConfigs(ctx context.Context, domainID string) ([]*models.DomainIDPConfig, error) {
 	var configs []*models.DomainIDPConfig
 	if err := s.db.WithContext(ctx).
 		Where("domain_id = ?", domainID).
@@ -388,7 +388,7 @@ func (s *Service) ListDomainIDPConfigs(ctx context.Context, domainID string) ([]
 }
 
 // GetDomainIDPConfig 获取域下指定 IDP 类型的配置
-func (s *Service) GetDomainIDPConfig(ctx context.Context, domainID, idpType string) (*models.DomainIDPConfig, error) {
+func (s *ProvisionService) GetDomainIDPConfig(ctx context.Context, domainID, idpType string) (*models.DomainIDPConfig, error) {
 	var cfg models.DomainIDPConfig
 	if err := s.db.WithContext(ctx).
 		Where("domain_id = ? AND idp_type = ?", domainID, idpType).
@@ -399,7 +399,7 @@ func (s *Service) GetDomainIDPConfig(ctx context.Context, domainID, idpType stri
 }
 
 // CreateDomainIDPConfig 创建域 IDP 配置（同时表示该 IDP 在此域下可用）
-func (s *Service) CreateDomainIDPConfig(ctx context.Context, domainID string, req *dto.DomainIDPConfigCreateRequest) (*models.DomainIDPConfig, error) {
+func (s *ProvisionService) CreateDomainIDPConfig(ctx context.Context, domainID string, req *dto.DomainIDPConfigCreateRequest) (*models.DomainIDPConfig, error) {
 	if _, err := s.getDomain(ctx, domainID); err != nil {
 		return nil, err
 	}
@@ -417,7 +417,7 @@ func (s *Service) CreateDomainIDPConfig(ctx context.Context, domainID string, re
 }
 
 // UpdateDomainIDPConfig 更新域 IDP 配置（JSON Merge Patch 语义）
-func (s *Service) UpdateDomainIDPConfig(ctx context.Context, domainID, idpType string, req *dto.DomainIDPConfigUpdateRequest) error {
+func (s *ProvisionService) UpdateDomainIDPConfig(ctx context.Context, domainID, idpType string, req *dto.DomainIDPConfigUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("priority", req.Priority),
 		patch.Field("strategy", req.Strategy),
@@ -438,7 +438,7 @@ func (s *Service) UpdateDomainIDPConfig(ctx context.Context, domainID, idpType s
 }
 
 // DeleteDomainIDPConfig 删除域 IDP 配置
-func (s *Service) DeleteDomainIDPConfig(ctx context.Context, domainID, idpType string) error {
+func (s *ProvisionService) DeleteDomainIDPConfig(ctx context.Context, domainID, idpType string) error {
 	result := s.db.WithContext(ctx).
 		Where("domain_id = ? AND idp_type = ?", domainID, idpType).
 		Delete(&models.DomainIDPConfig{})
@@ -454,7 +454,7 @@ func (s *Service) DeleteDomainIDPConfig(ctx context.Context, domainID, idpType s
 // ==================== Application IDP Config 相关 ====================
 
 // ListApplicationIDPConfigs 获取应用 IDP 配置列表（按 priority 降序）
-func (s *Service) ListApplicationIDPConfigs(ctx context.Context, appID string) ([]*models.ApplicationIDPConfig, error) {
+func (s *ProvisionService) ListApplicationIDPConfigs(ctx context.Context, appID string) ([]*models.ApplicationIDPConfig, error) {
 	var configs []*models.ApplicationIDPConfig
 	if err := s.db.WithContext(ctx).
 		Where("app_id = ?", appID).
@@ -466,7 +466,7 @@ func (s *Service) ListApplicationIDPConfigs(ctx context.Context, appID string) (
 }
 
 // CreateApplicationIDPConfig 创建应用 IDP 配置（仅允许添加该应用所属域下的 IDP）
-func (s *Service) CreateApplicationIDPConfig(ctx context.Context, appID string, req *dto.ApplicationIDPConfigCreateRequest) (*models.ApplicationIDPConfig, error) {
+func (s *ProvisionService) CreateApplicationIDPConfig(ctx context.Context, appID string, req *dto.ApplicationIDPConfigCreateRequest) (*models.ApplicationIDPConfig, error) {
 	if err := s.ensureIDPAllowedForApplication(ctx, appID, req.Type); err != nil {
 		return nil, err
 	}
@@ -484,7 +484,7 @@ func (s *Service) CreateApplicationIDPConfig(ctx context.Context, appID string, 
 }
 
 // UpdateApplicationIDPConfig 更新应用 IDP 配置（JSON Merge Patch 语义）
-func (s *Service) UpdateApplicationIDPConfig(ctx context.Context, appID, idpType string, req *dto.ApplicationIDPConfigUpdateRequest) error {
+func (s *ProvisionService) UpdateApplicationIDPConfig(ctx context.Context, appID, idpType string, req *dto.ApplicationIDPConfigUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("priority", req.Priority),
 		patch.Field("strategy", req.Strategy),
@@ -505,7 +505,7 @@ func (s *Service) UpdateApplicationIDPConfig(ctx context.Context, appID, idpType
 }
 
 // DeleteApplicationIDPConfig 删除应用 IDP 配置
-func (s *Service) DeleteApplicationIDPConfig(ctx context.Context, appID, idpType string) error {
+func (s *ProvisionService) DeleteApplicationIDPConfig(ctx context.Context, appID, idpType string) error {
 	result := s.db.WithContext(ctx).Where("app_id = ? AND `type` = ?", appID, idpType).Delete(&models.ApplicationIDPConfig{})
 	if result.Error != nil {
 		return fmt.Errorf("删除应用 IDP 配置失败: %w", result.Error)
@@ -519,7 +519,7 @@ func (s *Service) DeleteApplicationIDPConfig(ctx context.Context, appID, idpType
 // ==================== Service Challenge Config 相关 ====================
 
 // GetServiceChallengeSetting 获取服务 Challenge 配置
-func (s *Service) GetServiceChallengeSetting(ctx context.Context, serviceID, challengeType string) (*models.ServiceChallengeSetting, error) {
+func (s *ProvisionService) GetServiceChallengeSetting(ctx context.Context, serviceID, challengeType string) (*models.ServiceChallengeSetting, error) {
 	var cfg models.ServiceChallengeSetting
 	if err := s.db.WithContext(ctx).
 		Where("service_id = ? AND `type` = ?", serviceID, challengeType).
@@ -530,7 +530,7 @@ func (s *Service) GetServiceChallengeSetting(ctx context.Context, serviceID, cha
 }
 
 // ListServiceChallengeSettings 获取服务下所有 Challenge 配置
-func (s *Service) ListServiceChallengeSettings(ctx context.Context, serviceID string) ([]models.ServiceChallengeSetting, error) {
+func (s *ProvisionService) ListServiceChallengeSettings(ctx context.Context, serviceID string) ([]models.ServiceChallengeSetting, error) {
 	var settings []models.ServiceChallengeSetting
 	if err := s.db.WithContext(ctx).Where("service_id = ?", serviceID).Find(&settings).Error; err != nil {
 		return nil, fmt.Errorf("获取 Challenge 配置列表失败: %w", err)
@@ -539,7 +539,7 @@ func (s *Service) ListServiceChallengeSettings(ctx context.Context, serviceID st
 }
 
 // CreateServiceChallengeSetting 创建服务 Challenge 配置
-func (s *Service) CreateServiceChallengeSetting(ctx context.Context, serviceID string, req *dto.ServiceChallengeSettingCreateRequest) (*models.ServiceChallengeSetting, error) {
+func (s *ProvisionService) CreateServiceChallengeSetting(ctx context.Context, serviceID string, req *dto.ServiceChallengeSettingCreateRequest) (*models.ServiceChallengeSetting, error) {
 	if _, err := s.GetService(ctx, serviceID); err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (s *Service) CreateServiceChallengeSetting(ctx context.Context, serviceID s
 }
 
 // UpdateServiceChallengeSetting 更新服务 Challenge 配置（JSON Merge Patch 语义）
-func (s *Service) UpdateServiceChallengeSetting(ctx context.Context, serviceID, challengeType string, req *dto.ServiceChallengeSettingUpdateRequest) error {
+func (s *ProvisionService) UpdateServiceChallengeSetting(ctx context.Context, serviceID, challengeType string, req *dto.ServiceChallengeSettingUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("expires_in", req.ExpiresIn),
 	)
@@ -585,7 +585,7 @@ func (s *Service) UpdateServiceChallengeSetting(ctx context.Context, serviceID, 
 }
 
 // DeleteServiceChallengeSetting 删除服务 Challenge 配置
-func (s *Service) DeleteServiceChallengeSetting(ctx context.Context, serviceID, challengeType string) error {
+func (s *ProvisionService) DeleteServiceChallengeSetting(ctx context.Context, serviceID, challengeType string) error {
 	result := s.db.WithContext(ctx).
 		Where("service_id = ? AND `type` = ?", serviceID, challengeType).
 		Delete(&models.ServiceChallengeSetting{})
@@ -600,7 +600,7 @@ func (s *Service) DeleteServiceChallengeSetting(ctx context.Context, serviceID, 
 
 // ==================== 内部辅助方法 ====================
 
-func (s *Service) getDomain(ctx context.Context, domainID string) (*models.DomainRecord, error) {
+func (s *ProvisionService) getDomain(ctx context.Context, domainID string) (*models.DomainRecord, error) {
 	var rec models.DomainRecord
 	if err := s.db.WithContext(ctx).Where("domain_id = ?", domainID).First(&rec).Error; err != nil {
 		return nil, fmt.Errorf("域 %s 不存在: %w", domainID, err)
@@ -608,7 +608,7 @@ func (s *Service) getDomain(ctx context.Context, domainID string) (*models.Domai
 	return &rec, nil
 }
 
-func (s *Service) ensureIDPAllowedForApplication(ctx context.Context, appID, idpType string) error {
+func (s *ProvisionService) ensureIDPAllowedForApplication(ctx context.Context, appID, idpType string) error {
 	app, err := s.GetApplication(ctx, appID)
 	if err != nil {
 		return err

--- a/hermes/internal/provision.go
+++ b/hermes/internal/provision.go
@@ -2,8 +2,10 @@ package hermes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-json-experiment/json"
 	"gorm.io/gorm"
@@ -18,6 +20,76 @@ import (
 )
 
 // ==================== Domain 相关 ====================
+
+var (
+	ErrDomainAlreadyExists = errors.New("域已存在")
+	ErrInvalidDomain       = errors.New("域参数无效")
+)
+
+func validateDomainName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("name 不能为空")
+	}
+	if utf8.RuneCountInString(name) > 128 {
+		return "", fmt.Errorf("name 不能超过 128 个字符")
+	}
+	return name, nil
+}
+
+func validateDomainDescription(description string) (string, error) {
+	description = strings.TrimSpace(description)
+	if utf8.RuneCountInString(description) > 512 {
+		return "", fmt.Errorf("description 不能超过 512 个字符")
+	}
+	return description, nil
+}
+
+// CreateDomain 创建域。
+func (s *ProvisionService) CreateDomain(ctx context.Context, req *dto.DomainCreateRequest) (*models.Domain, error) {
+	domainID := strings.TrimSpace(req.DomainID)
+	if err := validation.ValidateID("domain_id", domainID); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+	}
+	name, err := validateDomainName(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+	}
+
+	var description *string
+	if req.Description != nil {
+		value, err := validateDomainDescription(*req.Description)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+		}
+		if value != "" {
+			description = &value
+		}
+	}
+
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&models.DomainRecord{}).
+		Where("domain_id = ?", domainID).Count(&count).Error; err != nil {
+		return nil, fmt.Errorf("检查域失败: %w", err)
+	}
+	if count > 0 {
+		return nil, fmt.Errorf("%w: %s", ErrDomainAlreadyExists, domainID)
+	}
+
+	record := &models.DomainRecord{
+		DomainID:    domainID,
+		Name:        name,
+		Description: description,
+	}
+	if err := s.db.WithContext(ctx).Create(record).Error; err != nil {
+		return nil, fmt.Errorf("创建域失败: %w", err)
+	}
+	return &models.Domain{
+		DomainID:    record.DomainID,
+		Name:        record.Name,
+		Description: record.Description,
+	}, nil
+}
 
 // GetDomain 获取域基础信息（仅 t_domain 元数据）
 func (s *ProvisionService) GetDomain(ctx context.Context, domainID string) (*models.Domain, error) {
@@ -51,8 +123,28 @@ func (s *ProvisionService) ListDomains(ctx context.Context) ([]models.Domain, er
 
 // UpdateDomain 更新域（仅 name、description）
 func (s *ProvisionService) UpdateDomain(ctx context.Context, domainID string, req *dto.DomainUpdateRequest) (*models.Domain, error) {
+	if err := validation.ValidateID("domain_id", domainID); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+	}
 	if _, err := s.getDomain(ctx, domainID); err != nil {
 		return nil, err
+	}
+	if req.Name.IsPresent() {
+		if !req.Name.HasValue() {
+			return nil, fmt.Errorf("%w: name 不能为空", ErrInvalidDomain)
+		}
+		name, err := validateDomainName(req.Name.Value())
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+		}
+		req.Name = patch.Set(name)
+	}
+	if req.Description.HasValue() {
+		description, err := validateDomainDescription(req.Description.Value())
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidDomain, err)
+		}
+		req.Description = patch.Set(description)
 	}
 	updates := patch.Collect(
 		patch.Field("name", req.Name),

--- a/hermes/internal/provision_domain_test.go
+++ b/hermes/internal/provision_domain_test.go
@@ -1,0 +1,64 @@
+package hermes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateDomainName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{name: "trims whitespace", value: "  Consumer  ", want: "Consumer"},
+		{name: "rejects blank", value: "  ", wantErr: true},
+		{name: "accepts 128 unicode characters", value: strings.Repeat("域", 128), want: strings.Repeat("域", 128)},
+		{name: "rejects more than 128 unicode characters", value: strings.Repeat("域", 129), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateDomainName(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateDomainName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("validateDomainName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDomainDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{name: "trims whitespace", value: "  Identity boundary  ", want: "Identity boundary"},
+		{name: "accepts empty", value: "", want: ""},
+		{name: "accepts 512 unicode characters", value: strings.Repeat("域", 512), want: strings.Repeat("域", 512)},
+		{name: "rejects more than 512 unicode characters", value: strings.Repeat("域", 513), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateDomainDescription(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateDomainDescription() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("validateDomainDescription() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/hermes/internal/resource.go
+++ b/hermes/internal/resource.go
@@ -16,7 +16,7 @@ import (
 // ==================== ApplicationServiceRelation 相关 ====================
 
 // SetApplicationServiceRelations 设置应用可访问的服务和关系
-func (s *Service) SetApplicationServiceRelations(ctx context.Context, req *dto.ApplicationServiceRelationRequest) error {
+func (s *ResourceService) SetApplicationServiceRelations(ctx context.Context, req *dto.ApplicationServiceRelationRequest) error {
 	if err := s.db.WithContext(ctx).Where("app_id = ? AND service_id = ?", req.AppID, req.ServiceID).
 		Delete(&models.ApplicationServiceRelation{}).Error; err != nil {
 		return fmt.Errorf("删除旧关系失败: %w", err)
@@ -36,7 +36,7 @@ func (s *Service) SetApplicationServiceRelations(ctx context.Context, req *dto.A
 }
 
 // ListApplicationServiceRelations 获取应用可访问的服务和关系
-func (s *Service) ListApplicationServiceRelations(ctx context.Context, appID string) ([]models.ApplicationServiceRelation, error) {
+func (s *ResourceService) ListApplicationServiceRelations(ctx context.Context, appID string) ([]models.ApplicationServiceRelation, error) {
 	var relations []models.ApplicationServiceRelation
 	if err := s.db.WithContext(ctx).Where("app_id = ?", appID).Find(&relations).Error; err != nil {
 		return nil, fmt.Errorf("获取应用服务关系失败: %w", err)
@@ -45,7 +45,7 @@ func (s *Service) ListApplicationServiceRelations(ctx context.Context, appID str
 }
 
 // GetServiceApplicationRelations 获取服务已授权给哪些应用及授予的权限
-func (s *Service) GetServiceApplicationRelations(ctx context.Context, serviceID string) ([]models.ApplicationServiceRelation, error) {
+func (s *ResourceService) GetServiceApplicationRelations(ctx context.Context, serviceID string) ([]models.ApplicationServiceRelation, error) {
 	var relations []models.ApplicationServiceRelation
 	if err := s.db.WithContext(ctx).Where("service_id = ?", serviceID).Find(&relations).Error; err != nil {
 		return nil, fmt.Errorf("获取服务已授权应用失败: %w", err)
@@ -54,7 +54,7 @@ func (s *Service) GetServiceApplicationRelations(ctx context.Context, serviceID 
 }
 
 // GetServiceAppRelations 获取某服务授予某应用的关系列表
-func (s *Service) GetServiceAppRelations(ctx context.Context, serviceID, appID string) ([]string, error) {
+func (s *ResourceService) GetServiceAppRelations(ctx context.Context, serviceID, appID string) ([]string, error) {
 	var relations []models.ApplicationServiceRelation
 	if err := s.db.WithContext(ctx).Where("service_id = ? AND app_id = ?", serviceID, appID).Find(&relations).Error; err != nil {
 		return nil, fmt.Errorf("获取服务应用关系失败: %w", err)
@@ -69,7 +69,7 @@ func (s *Service) GetServiceAppRelations(ctx context.Context, serviceID, appID s
 // ==================== Relationship 相关 ====================
 
 // CreateRelationship 创建关系
-func (s *Service) CreateRelationship(ctx context.Context, req *dto.RelationshipCreateRequest) (*models.Relationship, error) {
+func (s *ResourceService) CreateRelationship(ctx context.Context, req *dto.RelationshipCreateRequest) (*models.Relationship, error) {
 	var expiresAt *time.Time
 	if req.ExpiresAt != nil {
 		exp, err := time.Parse(time.RFC3339, *req.ExpiresAt)
@@ -95,7 +95,7 @@ func (s *Service) CreateRelationship(ctx context.Context, req *dto.RelationshipC
 }
 
 // DeleteRelationship 删除关系
-func (s *Service) DeleteRelationship(ctx context.Context, req *dto.RelationshipDeleteRequest) error {
+func (s *ResourceService) DeleteRelationship(ctx context.Context, req *dto.RelationshipDeleteRequest) error {
 	if err := s.db.WithContext(ctx).Where(
 		"service_id = ? AND subject_type = ? AND subject_id = ? AND relation = ? AND object_type = ? AND object_id = ?",
 		req.ServiceID, req.SubjectType, req.SubjectID, req.Relation, req.ObjectType, req.ObjectID,
@@ -112,14 +112,14 @@ var relationshipFilters = filter.Whitelist{
 }
 
 // ListRelationships 列出关系（游标分页）
-func (s *Service) ListRelationships(ctx context.Context, req *dto.ListRequest) (*pagination.Items[models.Relationship], error) {
+func (s *ResourceService) ListRelationships(ctx context.Context, req *dto.ListRequest) (*pagination.Items[models.Relationship], error) {
 	query := s.db.WithContext(ctx).Model(&models.Relationship{})
 	query = filter.Apply(query, req.Filter, relationshipFilters)
 	return pagination.CursorPaginate[models.Relationship](query, req.Pagination)
 }
 
 // ListRelationshipsBySubject 按精确条件查询关系（不分页），供内部服务调用
-func (s *Service) ListRelationshipsBySubject(ctx context.Context, serviceID, subjectType, subjectID string) ([]models.Relationship, error) {
+func (s *ResourceService) ListRelationshipsBySubject(ctx context.Context, serviceID, subjectType, subjectID string) ([]models.Relationship, error) {
 	var rels []models.Relationship
 	query := s.db.WithContext(ctx).Where("service_id = ? AND subject_type = ? AND subject_id = ?", serviceID, subjectType, subjectID)
 	if err := query.Find(&rels).Error; err != nil {
@@ -129,7 +129,7 @@ func (s *Service) ListRelationshipsBySubject(ctx context.Context, serviceID, sub
 }
 
 // UpdateRelationship 更新关系（JSON Merge Patch 语义）
-func (s *Service) UpdateRelationship(ctx context.Context, req *dto.RelationshipUpdateRequest) (*models.Relationship, error) {
+func (s *ResourceService) UpdateRelationship(ctx context.Context, req *dto.RelationshipUpdateRequest) (*models.Relationship, error) {
 	var rel models.Relationship
 	if err := s.db.WithContext(ctx).Where(
 		"service_id = ? AND subject_type = ? AND subject_id = ? AND relation = ? AND object_type = ? AND object_id = ?",
@@ -176,7 +176,7 @@ var appServiceRelationshipFilters = filter.Whitelist{
 }
 
 // verifyAppServiceAccess 验证应用是否有权访问该服务
-func (s *Service) verifyAppServiceAccess(ctx context.Context, appID, serviceID string) error {
+func (s *ResourceService) verifyAppServiceAccess(ctx context.Context, appID, serviceID string) error {
 	var app models.Application
 	if err := s.db.WithContext(ctx).Where("app_id = ?", appID).First(&app).Error; err != nil {
 		return fmt.Errorf("应用不存在: %w", err)
@@ -193,7 +193,7 @@ func (s *Service) verifyAppServiceAccess(ctx context.Context, appID, serviceID s
 }
 
 // ListAppServiceRelationships 列出应用服务下的关系（游标分页）
-func (s *Service) ListAppServiceRelationships(ctx context.Context, appID, serviceID string, req *dto.ListRequest) (*pagination.Items[models.Relationship], error) {
+func (s *ResourceService) ListAppServiceRelationships(ctx context.Context, appID, serviceID string, req *dto.ListRequest) (*pagination.Items[models.Relationship], error) {
 	if err := s.verifyAppServiceAccess(ctx, appID, serviceID); err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (s *Service) ListAppServiceRelationships(ctx context.Context, appID, servic
 }
 
 // CreateAppServiceRelationship 在应用服务下创建关系
-func (s *Service) CreateAppServiceRelationship(ctx context.Context, appID, serviceID string, req *dto.AppServiceRelationshipCreateRequest) (*models.Relationship, error) {
+func (s *ResourceService) CreateAppServiceRelationship(ctx context.Context, appID, serviceID string, req *dto.AppServiceRelationshipCreateRequest) (*models.Relationship, error) {
 	if err := s.verifyAppServiceAccess(ctx, appID, serviceID); err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (s *Service) CreateAppServiceRelationship(ctx context.Context, appID, servi
 }
 
 // UpdateAppServiceRelationship 在应用服务下更新关系（JSON Merge Patch 语义）
-func (s *Service) UpdateAppServiceRelationship(ctx context.Context, appID, serviceID string, relationshipID uint, req *dto.AppServiceRelationshipUpdateRequest) (*models.Relationship, error) {
+func (s *ResourceService) UpdateAppServiceRelationship(ctx context.Context, appID, serviceID string, relationshipID uint, req *dto.AppServiceRelationshipUpdateRequest) (*models.Relationship, error) {
 	if err := s.verifyAppServiceAccess(ctx, appID, serviceID); err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *Service) UpdateAppServiceRelationship(ctx context.Context, appID, servi
 }
 
 // DeleteAppServiceRelationship 在应用服务下删除关系
-func (s *Service) DeleteAppServiceRelationship(ctx context.Context, appID, serviceID string, relationshipID uint) error {
+func (s *ResourceService) DeleteAppServiceRelationship(ctx context.Context, appID, serviceID string, relationshipID uint) error {
 	if err := s.verifyAppServiceAccess(ctx, appID, serviceID); err != nil {
 		return err
 	}

--- a/hermes/internal/service.go
+++ b/hermes/internal/service.go
@@ -8,18 +8,49 @@ import (
 	"github.com/heliannuuthus/hermes/config"
 )
 
-// Service hermes 业务服务
-type Service struct {
+// Services 聚合 Hermes 各领域服务。
+type Services struct {
+	User      *UserService
+	Provision *ProvisionService
+	Resource  *ResourceService
+	Key       *KeyService
+}
+
+// UserService 负责用户、身份、凭证和用户组。
+type UserService struct {
 	db *gorm.DB
 }
 
-// NewService 创建 hermes 业务服务
-func NewService(db *gorm.DB) (*Service, error) {
+// ProvisionService 负责域、服务、应用和 IDP 配置。
+type ProvisionService struct {
+	db     *gorm.DB
+	keySvc *KeyService
+}
+
+// ResourceService 负责关系和应用服务关联。
+type ResourceService struct {
+	db *gorm.DB
+}
+
+// KeyService 负责密钥管理。
+type KeyService struct {
+	db *gorm.DB
+}
+
+// NewServices 创建并校验 Hermes 领域服务。
+func NewServices(db *gorm.DB) (*Services, error) {
 	if db == nil {
 		return nil, fmt.Errorf("数据库连接未初始化")
 	}
 	if _, err := config.GetDBEncKeyRaw(); err != nil {
 		return nil, fmt.Errorf("数据库加密模块初始化失败: %w", err)
 	}
-	return &Service{db: db}, nil
+
+	keySvc := &KeyService{db: db}
+	return &Services{
+		User:      &UserService{db: db},
+		Provision: &ProvisionService{db: db, keySvc: keySvc},
+		Resource:  &ResourceService{db: db},
+		Key:       keySvc,
+	}, nil
 }

--- a/hermes/internal/user.go
+++ b/hermes/internal/user.go
@@ -23,7 +23,7 @@ import (
 // ==================== User CRUD ====================
 
 // GetUserByOpenID 根据 OpenID 查找用户
-func (s *Service) GetUserByOpenID(ctx context.Context, openid string) (*models.User, error) {
+func (s *UserService) GetUserByOpenID(ctx context.Context, openid string) (*models.User, error) {
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("openid = ?", openid).First(&user).Error; err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (s *Service) GetUserByOpenID(ctx context.Context, openid string) (*models.U
 }
 
 // GetUserByIdentity 根据身份定位查找用户（domain + idp + t_openid）
-func (s *Service) GetUserByIdentity(ctx context.Context, domain, idp, tOpenID string) (*models.User, error) {
+func (s *UserService) GetUserByIdentity(ctx context.Context, domain, idp, tOpenID string) (*models.User, error) {
 	var matched models.UserIdentity
 	if err := s.db.WithContext(ctx).
 		Where("domain = ? AND idp = ? AND t_openid = ?", domain, idp, tOpenID).
@@ -43,7 +43,7 @@ func (s *Service) GetUserByIdentity(ctx context.Context, domain, idp, tOpenID st
 }
 
 // GetUserByEmail 根据邮箱查找用户（返回解密后的完整用户信息）
-func (s *Service) GetUserByEmail(ctx context.Context, email string) (*models.UserWithDecrypted, error) {
+func (s *UserService) GetUserByEmail(ctx context.Context, email string) (*models.UserWithDecrypted, error) {
 	user, err := s.getUserByEmail(ctx, email)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (s *Service) GetUserByEmail(ctx context.Context, email string) (*models.Use
 }
 
 // GetUserByUsername 根据用户名查找用户（最左模糊匹配）
-func (s *Service) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
+func (s *UserService) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("username LIKE ?", username+"%").First(&user).Error; err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s *Service) GetUserByUsername(ctx context.Context, username string) (*mode
 }
 
 // GetUserByPhone 根据手机号明文查找用户（内部哈希后查询，返回解密后的完整用户信息）
-func (s *Service) GetUserByPhone(ctx context.Context, phone string) (*models.UserWithDecrypted, error) {
+func (s *UserService) GetUserByPhone(ctx context.Context, phone string) (*models.UserWithDecrypted, error) {
 	phoneHash := hashPhone(phone)
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("phone = ?", phoneHash).First(&user).Error; err != nil {
@@ -71,7 +71,7 @@ func (s *Service) GetUserByPhone(ctx context.Context, phone string) (*models.Use
 }
 
 // GetDecryptedUserByOpenID 获取解密后的用户（解密手机号）
-func (s *Service) GetDecryptedUserByOpenID(ctx context.Context, openid string) (*models.UserWithDecrypted, error) {
+func (s *UserService) GetDecryptedUserByOpenID(ctx context.Context, openid string) (*models.UserWithDecrypted, error) {
 	user, err := s.GetUserByOpenID(ctx, openid)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (s *Service) GetDecryptedUserByOpenID(ctx context.Context, openid string) (
 }
 
 // GetDecryptedUserByIdentity 根据身份定位获取解密后的用户
-func (s *Service) GetDecryptedUserByIdentity(ctx context.Context, domain, idp, tOpenID string) (*models.UserWithDecrypted, error) {
+func (s *UserService) GetDecryptedUserByIdentity(ctx context.Context, domain, idp, tOpenID string) (*models.UserWithDecrypted, error) {
 	user, err := s.GetUserByIdentity(ctx, domain, idp, tOpenID)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (s *Service) GetDecryptedUserByIdentity(ctx context.Context, domain, idp, t
 
 // GetIdentities 根据 domain + idp + t_openid 查找该用户的全部身份
 // 用户不存在返回空切片（非 error），仅基础设施故障才返回 error
-func (s *Service) ListIdentitiesByIdentity(ctx context.Context, domain, idp, tOpenID string) (models.Identities, error) {
+func (s *UserService) ListIdentitiesByIdentity(ctx context.Context, domain, idp, tOpenID string) (models.Identities, error) {
 	var matched models.UserIdentity
 	query := s.db.WithContext(ctx).Where("idp = ? AND t_openid = ?", idp, tOpenID)
 	if domain != "" {
@@ -126,7 +126,7 @@ func (s *Service) ListIdentitiesByIdentity(ctx context.Context, domain, idp, tOp
 }
 
 // ListUserIdentities 获取用户所有身份关联
-func (s *Service) ListUserIdentities(ctx context.Context, openid string) (models.Identities, error) {
+func (s *UserService) ListUserIdentities(ctx context.Context, openid string) (models.Identities, error) {
 	var identities models.Identities
 	if err := s.db.WithContext(ctx).Where("uid = ?", openid).Find(&identities).Error; err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (s *Service) ListUserIdentities(ctx context.Context, openid string) (models
 }
 
 // GetUserIdentityByType 获取用户指定域和 IDP 类型的身份
-func (s *Service) GetUserIdentityByType(ctx context.Context, domain, openid, idpType string) (*models.UserIdentity, error) {
+func (s *UserService) GetUserIdentityByType(ctx context.Context, domain, openid, idpType string) (*models.UserIdentity, error) {
 	var identity models.UserIdentity
 	if err := s.db.WithContext(ctx).Where("domain = ? AND uid = ? AND idp = ?", domain, openid, idpType).First(&identity).Error; err != nil {
 		return nil, err
@@ -144,14 +144,14 @@ func (s *Service) GetUserIdentityByType(ctx context.Context, domain, openid, idp
 }
 
 // AddIdentity 添加身份关联
-func (s *Service) CreateIdentity(ctx context.Context, identity *models.UserIdentity) error {
+func (s *UserService) CreateIdentity(ctx context.Context, identity *models.UserIdentity) error {
 	return s.db.WithContext(ctx).Create(identity).Error
 }
 
 // ==================== User Write ====================
 
 // CreateUser 创建用户及其身份关联（认证身份 + global 身份）
-func (s *Service) CreateUser(ctx context.Context, identity *models.UserIdentity, userInfo *models.TUserInfo) (*models.UserWithDecrypted, error) {
+func (s *UserService) CreateUser(ctx context.Context, identity *models.UserIdentity, userInfo *models.TUserInfo) (*models.UserWithDecrypted, error) {
 	now := time.Now()
 	openid := models.GenerateOpenID()
 
@@ -207,7 +207,7 @@ func (s *Service) CreateUser(ctx context.Context, identity *models.UserIdentity,
 }
 
 // createWithIdentities 创建用户及多个身份关联（事务）
-func (s *Service) createWithIdentities(ctx context.Context, user *models.User, identities models.Identities) error {
+func (s *UserService) createWithIdentities(ctx context.Context, user *models.User, identities models.Identities) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(user).Error; err != nil {
 			return fmt.Errorf("创建用户失败: %w", err)
@@ -223,7 +223,7 @@ func (s *Service) createWithIdentities(ctx context.Context, user *models.User, i
 }
 
 // PatchUser patches user fields by openid.
-func (s *Service) PatchUser(ctx context.Context, openid string, updates map[string]any) error {
+func (s *UserService) PatchUser(ctx context.Context, openid string, updates map[string]any) error {
 	if phone, ok := updates["phone"]; ok {
 		delete(updates, "phone")
 		if phoneStr, ok := phone.(string); ok {
@@ -246,7 +246,7 @@ func (s *Service) PatchUser(ctx context.Context, openid string, updates map[stri
 // ==================== WebAuthn 凭证管理 ====================
 
 // CreateCredential 创建凭证（TOTP 类型自动加密 Secret）
-func (s *Service) CreateCredential(ctx context.Context, cred *models.UserCredential) error {
+func (s *UserService) CreateCredential(ctx context.Context, cred *models.UserCredential) error {
 	if models.CredentialType(cred.Type) == models.CredentialTypeTOTP && cred.Secret != "" {
 		encrypted, err := s.encryptSecret(cred.Secret, cred.OpenID)
 		if err != nil {
@@ -258,7 +258,7 @@ func (s *Service) CreateCredential(ctx context.Context, cred *models.UserCredent
 }
 
 // GetCredentialByID 根据凭证 ID 获取凭证（TOTP 类型自动解密 Secret）
-func (s *Service) GetCredentialByID(ctx context.Context, credentialID string) (*models.UserCredential, error) {
+func (s *UserService) GetCredentialByID(ctx context.Context, credentialID string) (*models.UserCredential, error) {
 	var cred models.UserCredential
 	if err := s.db.WithContext(ctx).Where("credential_id = ?", credentialID).First(&cred).Error; err != nil {
 		return nil, err
@@ -268,7 +268,7 @@ func (s *Service) GetCredentialByID(ctx context.Context, credentialID string) (*
 }
 
 // ListUserCredentials 获取用户所有凭证（TOTP 类型自动解密 Secret）
-func (s *Service) ListUserCredentials(ctx context.Context, openid string) ([]models.UserCredential, error) {
+func (s *UserService) ListUserCredentials(ctx context.Context, openid string) ([]models.UserCredential, error) {
 	var credentials []models.UserCredential
 	if err := s.db.WithContext(ctx).Where("openid = ?", openid).Find(&credentials).Error; err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (s *Service) ListUserCredentials(ctx context.Context, openid string) ([]mod
 }
 
 // ListUserCredentialsByType 获取用户指定类型的凭证（TOTP 类型自动解密 Secret）
-func (s *Service) ListUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
+func (s *UserService) ListUserCredentialsByType(ctx context.Context, openid, credType string) ([]models.UserCredential, error) {
 	var credentials []models.UserCredential
 	if err := s.db.WithContext(ctx).Where("openid = ? AND type = ?", openid, credType).Find(&credentials).Error; err != nil {
 		return nil, err
@@ -288,7 +288,7 @@ func (s *Service) ListUserCredentialsByType(ctx context.Context, openid, credTyp
 }
 
 // PatchCredential patches credential fields by credential_id.
-func (s *Service) PatchCredential(ctx context.Context, credentialID string, updates map[string]any) error {
+func (s *UserService) PatchCredential(ctx context.Context, credentialID string, updates map[string]any) error {
 	if signCount, ok := updates["sign_count"]; ok {
 		delete(updates, "sign_count")
 		updates["secret"] = gorm.Expr("JSON_SET(secret, '$.sign_count', ?)", signCount)
@@ -300,17 +300,17 @@ func (s *Service) PatchCredential(ctx context.Context, credentialID string, upda
 }
 
 // DeleteCredential 删除凭证
-func (s *Service) DeleteCredential(ctx context.Context, openid, credentialID string) error {
+func (s *UserService) DeleteCredential(ctx context.Context, openid, credentialID string) error {
 	return s.db.WithContext(ctx).Where("openid = ? AND credential_id = ?", openid, credentialID).Delete(&models.UserCredential{}).Error
 }
 
 // DeleteUserCredentialsByType deletes all credentials of a type for a user.
-func (s *Service) DeleteUserCredentialsByType(ctx context.Context, openid, credType string) error {
+func (s *UserService) DeleteUserCredentialsByType(ctx context.Context, openid, credType string) error {
 	return s.db.WithContext(ctx).Where("openid = ? AND type = ?", openid, credType).Delete(&models.UserCredential{}).Error
 }
 
 // GetOpenIDByCredentialID 根据凭证 ID 获取用户 OpenID
-func (s *Service) GetOpenIDByCredentialID(ctx context.Context, credentialID string) (string, error) {
+func (s *UserService) GetOpenIDByCredentialID(ctx context.Context, credentialID string) (string, error) {
 	var cred models.UserCredential
 	if err := s.db.WithContext(ctx).
 		Select("openid").
@@ -325,7 +325,7 @@ func (s *Service) GetOpenIDByCredentialID(ctx context.Context, credentialID stri
 }
 
 // GetCredentialByInternalID 根据内部主键 ID 获取凭证（TOTP 类型自动解密 Secret）
-func (s *Service) GetCredentialByInternalID(ctx context.Context, id uint) (*models.UserCredential, error) {
+func (s *UserService) GetCredentialByInternalID(ctx context.Context, id uint) (*models.UserCredential, error) {
 	var cred models.UserCredential
 	if err := s.db.WithContext(ctx).Where("_id = ?", id).First(&cred).Error; err != nil {
 		return nil, err
@@ -335,7 +335,7 @@ func (s *Service) GetCredentialByInternalID(ctx context.Context, id uint) (*mode
 }
 
 // getUserByEmail 根据邮箱查找用户（内部使用，返回基础 User）
-func (s *Service) getUserByEmail(ctx context.Context, email string) (*models.User, error) {
+func (s *UserService) getUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("email = ?", email).First(&user).Error; err != nil {
 		return nil, err
@@ -351,7 +351,7 @@ var groupFilters = filter.Whitelist{
 }
 
 // CreateGroup 创建组
-func (s *Service) CreateGroup(ctx context.Context, req *dto.GroupCreateRequest) (*models.Group, error) {
+func (s *UserService) CreateGroup(ctx context.Context, req *dto.GroupCreateRequest) (*models.Group, error) {
 	group := &models.Group{
 		GroupID:     req.GroupID,
 		ServiceID:   req.ServiceID,
@@ -365,7 +365,7 @@ func (s *Service) CreateGroup(ctx context.Context, req *dto.GroupCreateRequest) 
 }
 
 // GetGroup 获取组
-func (s *Service) GetGroup(ctx context.Context, groupID string) (*models.Group, error) {
+func (s *UserService) GetGroup(ctx context.Context, groupID string) (*models.Group, error) {
 	var group models.Group
 	if err := s.db.WithContext(ctx).Where("group_id = ?", groupID).First(&group).Error; err != nil {
 		return nil, err
@@ -374,14 +374,14 @@ func (s *Service) GetGroup(ctx context.Context, groupID string) (*models.Group, 
 }
 
 // ListGroups 列出组（游标分页）
-func (s *Service) ListGroups(ctx context.Context, req *dto.ListRequest) (*pagination.Items[models.Group], error) {
+func (s *UserService) ListGroups(ctx context.Context, req *dto.ListRequest) (*pagination.Items[models.Group], error) {
 	query := s.db.WithContext(ctx).Model(&models.Group{})
 	query = filter.Apply(query, req.Filter, groupFilters)
 	return pagination.CursorPaginate[models.Group](query, req.Pagination)
 }
 
 // UpdateGroup 更新组（JSON Merge Patch 语义）
-func (s *Service) UpdateGroup(ctx context.Context, groupID string, req *dto.GroupUpdateRequest) error {
+func (s *UserService) UpdateGroup(ctx context.Context, groupID string, req *dto.GroupUpdateRequest) error {
 	updates := patch.Collect(
 		patch.Field("name", req.Name),
 		patch.Field("description", req.Description),
@@ -393,7 +393,7 @@ func (s *Service) UpdateGroup(ctx context.Context, groupID string, req *dto.Grou
 }
 
 // DeleteGroup 删除组（级联删除成员关系）
-func (s *Service) DeleteGroup(ctx context.Context, groupID string) error {
+func (s *UserService) DeleteGroup(ctx context.Context, groupID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("object_type = ? AND object_id = ? AND relation = ?", "group", groupID, "member").
 			Delete(&models.Relationship{}).Error; err != nil {
@@ -407,7 +407,7 @@ func (s *Service) DeleteGroup(ctx context.Context, groupID string) error {
 }
 
 // SetGroupMembers 设置组成员（全量替换，通过 Relationship 表实现）
-func (s *Service) SetGroupMembers(ctx context.Context, req *dto.GroupMemberRequest) error {
+func (s *UserService) SetGroupMembers(ctx context.Context, req *dto.GroupMemberRequest) error {
 	group, err := s.GetGroup(ctx, req.GroupID)
 	if err != nil {
 		return fmt.Errorf("组不存在: %w", err)
@@ -437,7 +437,7 @@ func (s *Service) SetGroupMembers(ctx context.Context, req *dto.GroupMemberReque
 }
 
 // GetGroupMembers 获取组成员列表
-func (s *Service) GetGroupMembers(ctx context.Context, groupID string) ([]string, error) {
+func (s *UserService) GetGroupMembers(ctx context.Context, groupID string) ([]string, error) {
 	var rels []models.Relationship
 	if err := s.db.WithContext(ctx).
 		Where("object_type = ? AND object_id = ? AND relation = ? AND subject_type = ?", "group", groupID, "member", "user").
@@ -487,7 +487,7 @@ func hashPhone(phone string) string {
 // ==================== 凭证加解密辅助 ====================
 
 // encryptSecret 加密凭证密钥（AES-256-GCM，openid 作为 AAD）
-func (s *Service) encryptSecret(plaintext, openid string) (string, error) {
+func (s *UserService) encryptSecret(plaintext, openid string) (string, error) {
 	key, err := config.GetDBEncKeyRaw()
 	if err != nil {
 		return "", fmt.Errorf("获取加密密钥失败: %w", err)
@@ -496,7 +496,7 @@ func (s *Service) encryptSecret(plaintext, openid string) (string, error) {
 }
 
 // decryptSecret 解密凭证密钥
-func (s *Service) decryptSecret(ciphertext, openid string) (string, error) {
+func (s *UserService) decryptSecret(ciphertext, openid string) (string, error) {
 	key, err := config.GetDBEncKeyRaw()
 	if err != nil {
 		return "", fmt.Errorf("获取加密密钥失败: %w", err)
@@ -505,7 +505,7 @@ func (s *Service) decryptSecret(ciphertext, openid string) (string, error) {
 }
 
 // decryptCredentialSecret 解密单个凭证的 Secret（仅 TOTP 类型）
-func (s *Service) decryptCredentialSecret(cred *models.UserCredential) {
+func (s *UserService) decryptCredentialSecret(cred *models.UserCredential) {
 	if models.CredentialType(cred.Type) == models.CredentialTypeTOTP && cred.Secret != "" {
 		plain, err := s.decryptSecret(cred.Secret, cred.OpenID)
 		if err != nil {
@@ -517,7 +517,7 @@ func (s *Service) decryptCredentialSecret(cred *models.UserCredential) {
 }
 
 // decryptCredentialSecrets 批量解密凭证的 Secret（仅 TOTP 类型）
-func (s *Service) decryptCredentialSecrets(creds []models.UserCredential) {
+func (s *UserService) decryptCredentialSecrets(creds []models.UserCredential) {
 	for i := range creds {
 		s.decryptCredentialSecret(&creds[i])
 	}

--- a/hermes/main.go
+++ b/hermes/main.go
@@ -105,6 +105,7 @@ func startHTTP(services *hermes.Services) {
 		domains := api.Group("/domains")
 		{
 			domains.GET("", handler.ListDomains)
+			domains.POST("", adminRelation, handler.CreateDomain)
 			domains.GET("/:domain_id", handler.GetDomain)
 			domains.PATCH("/:domain_id", adminRelation, handler.UpdateDomain)
 			domains.DELETE("/:domain_id", adminRelation, handler.DeleteDomain)

--- a/hermes/main.go
+++ b/hermes/main.go
@@ -34,17 +34,17 @@ func main() {
 
 	db := hermesconfig.InitDB()
 
-	svc, err := hermes.NewService(db)
+	services, err := hermes.NewServices(db)
 	if err != nil {
 		logger.Fatalf("初始化 Hermes 失败: %v", err)
 	}
 
-	grpcServer, lis, err := newGRPCServer(svc)
+	grpcServer, lis, err := newGRPCServer(services)
 	if err != nil {
 		logger.Fatalf("初始化 Hermes gRPC 服务失败: %v", err)
 	}
 	go serveGRPC(grpcServer, lis)
-	startHTTP(svc)
+	startHTTP(services)
 }
 
 func initTokenManager() {
@@ -57,7 +57,7 @@ func initTokenManager() {
 	}
 }
 
-func newGRPCServer(svc *hermes.Service) (*grpc.Server, net.Listener, error) {
+func newGRPCServer(services *hermes.Services) (*grpc.Server, net.Listener, error) {
 	lc := net.ListenConfig{}
 	lis, err := lc.Listen(context.Background(), "tcp", ":50051")
 	if err != nil {
@@ -65,10 +65,10 @@ func newGRPCServer(svc *hermes.Service) (*grpc.Server, net.Listener, error) {
 	}
 
 	s := grpc.NewServer()
-	hermesv1.RegisterProvisionServiceServer(s, hermesgrpc.NewProvisionServiceServer(svc))
-	hermesv1.RegisterResourceServiceServer(s, hermesgrpc.NewResourceServiceServer(svc))
-	hermesv1.RegisterKeyServiceServer(s, hermesgrpc.NewKeyServiceServer(svc))
-	hermesv1.RegisterUserServiceServer(s, hermesgrpc.NewUserServiceServer(svc))
+	hermesv1.RegisterProvisionServiceServer(s, hermesgrpc.NewProvisionServiceServer(services.Provision))
+	hermesv1.RegisterResourceServiceServer(s, hermesgrpc.NewResourceServiceServer(services.Resource))
+	hermesv1.RegisterKeyServiceServer(s, hermesgrpc.NewKeyServiceServer(services.Key))
+	hermesv1.RegisterUserServiceServer(s, hermesgrpc.NewUserServiceServer(services.User))
 	return s, lis, nil
 }
 
@@ -79,7 +79,7 @@ func serveGRPC(s *grpc.Server, lis net.Listener) {
 	}
 }
 
-func startHTTP(svc *hermes.Service) {
+func startHTTP(services *hermes.Services) {
 	if !config.IsDebug() {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -91,7 +91,7 @@ func startHTTP(svc *hermes.Service) {
 		c.JSON(200, gin.H{"status": "ok"})
 	})
 
-	handler := hermes.NewHandler(svc)
+	handler := hermes.NewHandler(services)
 
 	hermesAud := hermesconfig.GetAegisAudience()
 	hermesGuard, err := guard.NewGin(hermesAud)


### PR DESCRIPTION
## Summary

- add Hermes domain provisioning DTOs, service logic, and handlers
- register the provisioning route and supporting Makefile workflow
- cover domain provisioning behavior with tests
- install a project-local golangci-lint using the Go version selected by `go.work`

## Why

Domain creation now has an explicit provisioning path through the Hermes service layer. The lint workflow no longer depends on a globally installed binary compiled by an older Go release. Its cache path includes both the selected Go toolchain and golangci-lint version, so upgrading either automatically rebuilds the tool.

## Validation

- `make test`
- `make lint` — golangci-lint v2.12.2 built with Go 1.26.0; all six modules report zero issues.